### PR TITLE
Remove --use-hwthread-cpus flag and trigger on pull request

### DIFF
--- a/.github/workflows/.github-ci.yml
+++ b/.github/workflows/.github-ci.yml
@@ -27,7 +27,6 @@ jobs:
           ln -s /home/user/4C/build/4C config/4C
           ln -s /home/user/4C/build/post_ensight config/post_ensight
           ln -s /home/user/4C/build/post_processor config/post_processor
-          # /usr/bin/mpirun --bind-to none --use-hwthread-cpus -np 2 config/4C /home/user/4C/tests/input_files/solid_runtime_hex8.dat out
           $PYTHON_PACKAGE_MANAGER env create -f environment.yml
           $PYTHON_PACKAGE_MANAGER activate queens
           pip install -e .[develop]

--- a/.github/workflows/.github-ci.yml
+++ b/.github/workflows/.github-ci.yml
@@ -6,7 +6,7 @@ env:
   PYTHON_PACKAGE_MANAGER: "conda"  # Python package manager to create the python environments
 name: github_ci
 
-on: [push]
+on: [pull_request]
 
 jobs:
   run_tests:

--- a/tests/integration_tests/fourc/test_fourc_mc.py
+++ b/tests/integration_tests/fourc/test_fourc_mc.py
@@ -64,7 +64,6 @@ def test_fourc_mc(
         input_templates=fourc_input_file_template,
         executable=fourc_executable,
         data_processor=data_processor,
-        mpi_cmd="/usr/bin/mpirun --bind-to none --use-hwthread-cpus",
     )
     model = SimulationModel(scheduler=scheduler, driver=driver)
     iterator = MonteCarloIterator(


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Why is this change required?  What problem does it solve?
-->
As queens is public now, we have more cores available on the test runner and can therefore remove the `--use-hwthread-cpus` flag for the mpi command.

The trigger for the ci is changed to `pull_request`.

## Related Issues and Merge Requests
<!--
If applicable, let us know how this merge request is related to any other open issues or pull requests:
-->
* Closes
* Blocks
* Is blocked by
* Follows
* Precedes
* Related to
* Part of
* Composed of

## How Has This Been Tested?
<!--
Choose from these suggestions if applicable and fill the missing options.
Feel free to provide further information if useful or necessary.
-->

## Checklist
<!--
Go over all the following points, and put an `x` in all the boxes that apply. If you are unsure about any of these, please ask; we are here to help.
-->
- [ ] My commit messages mention the appropriate issue numbers (advised but optional).
- [ ] I mention the appropriate issue numbers in this MR.
- [ ] I updated documentation where necessary.
- [ ] I updated the README where necessary
- [ ] I have added as (few,) small and fast tests as possible to cover my changes.

## Additional Information
<!--
Is there anything else your fellow developers need to know in evaluating this merge request?
Feel free to add supplementary material here (e.g. screen output, log files, screenshots)
-->

## Interested Parties
<!--
If there's anyone you think should be looped in on this merge request, feel free to @mention them here. In particular, @mention possible reviewers as well as the maintainers of all the files you've touched.
-->

Possible reviewers:

Other interested parties:
