### PR TITLE
Change bibkey in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,15 +90,14 @@ if __name__ == "__main__":
 Your contributions are welcome! Please follow our [contributing guidelines](https://github.com/queens-py/queens/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/queens-py/queens/blob/main/CODE_OF_CONDUCT.md).
 
 ## :page_with_curl: How to cite
-If you use QUEENS in your work, please cite the [QUEENS paper](https://arxiv.org/?) and relevant method papers.
+If you use QUEENS in your work, please cite the relevant method papers and
 
 ```bib
-@inproceedings{queens,
-  title={QUEENS: An Open-Source Python Framework for Solver-
-Independent Analyses of Large-Scale Computational Models},
-  author={Qommunity},
-  pages={1--2},
-  year={2025}
+@misc{queens,
+  author       = {QUEENS},
+  title        = {QUEENS: An Open-Source Python Framework for Solver-Independent Analyses of Large-Scale Computational Models},
+  year         = {2025},
+  howpublished = {\url{https://www.queens-py.org}}
 }
 ```
 


### PR DESCRIPTION
## Description and Context
This MR changes the citation bibkey to the website temporarily. Once a publication by the QUEENS maintainers is available, this can be changed.

## Related Issues and Pull Requests
* Closes
* Blocks
* Is blocked by
* Follows
* Precedes
* Related to
* Part of
* Composed of

## How Has This Been Tested?
## Checklist
- [ ] My commit messages mention the appropriate issue numbers (advised but optional).
- [ ] I mention the appropriate issue numbers in this PR.
- [ ] I updated documentation where necessary.
- [ ] I have added tests to cover my changes.

## Additional Information

## Interested Parties

Possible reviewers:

Other interested parties:
