### PR TITLE
fix(build_documentation): only start deploy-documentation job on main branch

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -39,6 +39,7 @@ jobs:
 
   deploy-documentation:
     needs: build-documentation
+    if: ${{github.ref == 'refs/heads/main'}}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -46,5 +47,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        if: ${{github.ref == 'refs/heads/main'}}
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Why is this change required? What problem does it solve?
-->
This PR avoids an error in the deploy-documentation job in our build_documentation workflow when this workflow is manually triggered on a branch other than main. Before, this job would fail on such a branch because only the main branch is allowed to deploy to github-pages:
![image](https://github.com/user-attachments/assets/29c0a371-d25e-4550-beba-3865d0653938)

With this PR, the deploy-documentation job is only started if the workflow is triggered on the main branch and skipped on other branches:
![image](https://github.com/user-attachments/assets/4ed537cd-d0f6-4786-a562-c726ec3b8283)

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests:
-->
* Closes
* Blocks
* Is blocked by
* Follows
* Precedes
* Related to
* Part of
* Composed of

## How Has This Been Tested?
<!--
Choose from these suggestions if applicable and fill the missing options.
Feel free to provide further information if useful or necessary.
-->

## Checklist
<!--
Go over all the following points, and put an `X` in all the boxes that apply. If you are unsure about any of these, please ask; we are here to help.
-->
- [ ] My commit messages mention the appropriate issue numbers (advised but optional).
- [ ] I mention the appropriate issue numbers in this PR.
- [ ] I updated documentation where necessary.
- [ ] I have added tests to cover my changes.

## Additional Information
<!--
Is there anything else your fellow developers need to know in evaluating this pull request?
Feel free to add supplementary material here (e.g. screen output, log files, screenshots)
-->

## Interested Parties
<!--
If there's anyone you think should be looped in on this pull request, feel free to @mention them here. In particular, @mention possible reviewers as well as the maintainers of all the files you've touched.
-->

Possible reviewers:

Other interested parties:
