### PR TITLE
Set unit and intergrations test as default pytest marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,14 +59,14 @@ multi_line_output = 3
 include_trailing_comma = true
 
 [tool.ruff.lint]
-select = ["D"] # pydocstyle rules
+select = ["D"]    # pydocstyle rules
 ignore = ["D104"] # Missing docstring in public package
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
 
 [tool.pytest.ini_options]
-addopts = '-m "not benchmark and not lnm_cluster and not imcs_cluster" --doctest-modules --doctest-continue-on-failure --doctest-ignore-import-errors'
+addopts = '-m "unit_tests or integration_tests" --doctest-modules --doctest-continue-on-failure --doctest-ignore-import-errors'
 testpaths = ["tests"]
 pythonpath = ["test_utils"]
 markers = [
@@ -97,48 +97,48 @@ directory = "html_coverage_report"
 
 [tool.liccheck]
 authorized_licenses = [
-        "apache",
-        "apache 2.0",
-        "Apache-2.0",
-        "apache software license",
-        "apache license, version 2.0",
-        "apache license version 2.0",
-        "apache license 2.0",
-        "apache software",
-        "bsd",
-        "new bsd",
-        "bsd license",
-        "new bsd license",
-        "3-clause bsd",
-        "BSD 3-Clause",
-        "BSD-3-Clause",
-        "simplified bsd",
-        "CMU License (MIT-CMU)",
-        "gnu lgpl",
-        "GNU Library or Lesser General Public License (LGPL)",
-        "lgpl",
-        "historical permission notice and disclaimer (hpnd)",
-        "isc",
-        "isc license",
-        "isc license (iscl)",
-        "mit",
-        "mit license",
-        "mozilla public license 2.0",
-        "mozilla public license 2.0 (mpl 2.0)",
-        "python software foundation",
-        "python software foundation license",
-        "University of Illinois/NCSA Open Source",
-        "zlib/libpng",
+    "apache",
+    "apache 2.0",
+    "Apache-2.0",
+    "apache software license",
+    "apache license, version 2.0",
+    "apache license version 2.0",
+    "apache license 2.0",
+    "apache software",
+    "bsd",
+    "new bsd",
+    "bsd license",
+    "new bsd license",
+    "3-clause bsd",
+    "BSD 3-Clause",
+    "BSD-3-Clause",
+    "simplified bsd",
+    "CMU License (MIT-CMU)",
+    "gnu lgpl",
+    "GNU Library or Lesser General Public License (LGPL)",
+    "lgpl",
+    "historical permission notice and disclaimer (hpnd)",
+    "isc",
+    "isc license",
+    "isc license (iscl)",
+    "mit",
+    "mit license",
+    "mozilla public license 2.0",
+    "mozilla public license 2.0 (mpl 2.0)",
+    "python software foundation",
+    "python software foundation license",
+    "University of Illinois/NCSA Open Source",
+    "zlib/libpng",
 ]
 unauthorized_licenses = [
-        "gpl v3",
-        "gpl v2",
-        "gpl",
-        "GNU general public license (gpl)",
-        "IBM Public License",
-        "RPL",
-        "Reciprocal Public License",
-        "Sleepycat License",
+    "gpl v3",
+    "gpl v2",
+    "gpl",
+    "GNU general public license (gpl)",
+    "IBM Public License",
+    "RPL",
+    "Reciprocal Public License",
+    "Sleepycat License",
 ]
 [tool.liccheck.authorized_packages]
 # filelock has public domain license without restrictions


### PR DESCRIPTION
## Description and Context
This PR sets the default pytest markers settings such that the integration and unit tests are checked. The 4C tests are not used since they are only an optional dependency.

## Related Issues and Pull Requests
* Closes
* Blocks
* Is blocked by
* Follows
* Precedes
* Related to #108 
* Part of
* Composed of

## How Has This Been Tested?
<!--
Choose from these suggestions if applicable and fill the missing options.
Feel free to provide further information if useful or necessary.
-->

## Checklist
- [ ] My commit messages mention the appropriate issue numbers (advised but optional).
- [ ] I mention the appropriate issue numbers in this PR.
- [ ] I updated documentation where necessary.
- [ ] I have added tests to cover my changes.

## Additional Information


## Interested Parties

Possible reviewers:

Other interested parties:
