### PR TITLE
fix: log-likelihood shapes

### DIFF
--- a/queens/example_simulator_functions/gaussian_logpdf.py
+++ b/queens/example_simulator_functions/gaussian_logpdf.py
@@ -53,7 +53,7 @@ def gaussian_1d_logpdf(x):
     Returns:
         float: The logpdf evaluated at *x*
     """
-    y = np.atleast_2d(STANDARD_NORMAL.logpdf(x))
+    y = STANDARD_NORMAL.logpdf(x)
     return y
 
 

--- a/queens/iterators/sequential_monte_carlo_iterator.py
+++ b/queens/iterators/sequential_monte_carlo_iterator.py
@@ -157,9 +157,9 @@ class SequentialMonteCarloIterator(Iterator):
         # TODO: use normalised weights? # pylint: disable=fixme
         self.weights = np.ones((self.num_particles, 1))
 
-        self.log_likelihood = np.zeros((self.num_particles, 1))
-        self.log_prior = np.zeros((self.num_particles, 1))
-        self.log_posterior = np.zeros((self.num_particles, 1))
+        self.log_likelihood = np.zeros(self.num_particles)
+        self.log_prior = np.zeros(self.num_particles)
+        self.log_posterior = np.zeros(self.num_particles)
 
         self.ess = []
         self.ess_cur = 0.0
@@ -206,10 +206,10 @@ class SequentialMonteCarloIterator(Iterator):
         # draw initial particles from prior distribution
         self.particles = self.parameters.draw_samples(self.num_particles)
         self.log_likelihood = self.eval_log_likelihood(self.particles)
-        self.log_prior = self.eval_log_prior(self.particles).reshape(-1, 1)
+        self.log_prior = self.eval_log_prior(self.particles)
         self.log_posterior = self.log_likelihood + self.log_prior
         # initialize importance weights
-        self.weights = np.ones((self.num_particles, 1))
+        self.weights = np.ones(self.num_particles)
         self.ess_cur = self.num_particles
         self.ess.append(self.ess_cur)
 
@@ -343,13 +343,13 @@ class SequentialMonteCarloIterator(Iterator):
         """
         # draw from multinomial distribution to decide
         # the frequency of individual particles
-        particle_freq = np.random.multinomial(self.num_particles, np.squeeze(self.weights))
+        particle_freq = np.random.multinomial(self.num_particles, self.weights)
 
         idx_list = []
         for idx, freq in enumerate(particle_freq):
             idx_list += [idx] * freq
 
-        resampled_weights = np.ones((self.num_particles, 1))
+        resampled_weights = np.ones(self.num_particles)
 
         return (
             self.particles[idx_list],
@@ -398,7 +398,7 @@ class SequentialMonteCarloIterator(Iterator):
 
             # estimate current covariance matrix
             cov_mat = np.atleast_2d(
-                np.cov(self.particles, ddof=0, aweights=np.squeeze(self.weights), rowvar=False)
+                np.cov(self.particles, ddof=0, aweights=self.weights, rowvar=False)
             )
 
             # scale covariance based on average acceptance rate of last rejuvenation step

--- a/queens/models/likelihood_models/bayesian_mf_gaussian_likelihood.py
+++ b/queens/models/likelihood_models/bayesian_mf_gaussian_likelihood.py
@@ -343,7 +343,7 @@ class BMFGaussianModel(LikelihoodModel):
                 variance_vec.flatten() + self.noise_var.flatten()
             )
             log_lik_mf_lst.append(self.normal_distribution.logpdf(m_f_vec.reshape(1, -1)))
-        log_lik_mf_output = np.array(log_lik_mf_lst).reshape(-1, 1)
+        log_lik_mf_output = np.array(log_lik_mf_lst).reshape(-1)
 
         if self.min_log_lik_mf is None:
             self.min_log_lik_mf = np.min(log_lik_mf_output)

--- a/queens/utils/mcmc_utils.py
+++ b/queens/utils/mcmc_utils.py
@@ -51,7 +51,7 @@ def mh_select(log_acceptance_probability, current_sample, proposed_sample):
 
     bool_idx = isfinite * accept
 
-    selected_samples = np.where(bool_idx, proposed_sample, current_sample)
+    selected_samples = np.where(bool_idx[:, np.newaxis], proposed_sample, current_sample)
 
     return selected_samples, bool_idx
 

--- a/tests/integration_tests/python/conftest.py
+++ b/tests/integration_tests/python/conftest.py
@@ -116,7 +116,7 @@ def fixture_target_density_gaussian_1d():
     def target_density_gaussian_1d(self, samples):  # pylint: disable=unused-argument
         """Target posterior density."""
         samples = np.atleast_2d(samples)
-        log_likelihood = gaussian_1d_logpdf(samples).reshape(-1, 1)
+        log_likelihood = gaussian_1d_logpdf(samples)
 
         return log_likelihood
 
@@ -130,7 +130,7 @@ def fixture_target_density_gaussian_2d():
     def target_density_gaussian_2d(self, samples):  # pylint: disable=unused-argument
         """Target likelihood density."""
         samples = np.atleast_2d(samples)
-        log_likelihood = gaussian_2d_logpdf(samples).reshape(-1, 1)
+        log_likelihood = gaussian_2d_logpdf(samples)
 
         return log_likelihood
 
@@ -144,7 +144,7 @@ def fixture_target_density_gaussian_2d_with_grad():
     def target_density_gaussian_2d_with_grad(self, samples):  # pylint: disable=unused-argument
         """Target likelihood density."""
         samples = np.atleast_2d(samples)
-        log_likelihood = gaussian_2d_logpdf(samples).flatten()
+        log_likelihood = gaussian_2d_logpdf(samples)
 
         cov = [[1.0, 0.5], [0.5, 1.0]]
         cov_inverse = np.linalg.inv(cov)

--- a/tests/integration_tests/python/test_smc_bayes_temper_multivariate_gaussian_mixture.py
+++ b/tests/integration_tests/python/test_smc_bayes_temper_multivariate_gaussian_mixture.py
@@ -129,7 +129,7 @@ def test_smc_bayes_temper_multivariate_gaussian_mixture(
 def target_density(self, samples):  # pylint: disable=unused-argument
     """Compute the log likelihood of samples under a Gaussian mixture model."""
     samples = np.atleast_2d(samples)
-    log_likelihood = gaussian_mixture_4d_logpdf(samples).reshape(-1, 1)
+    log_likelihood = gaussian_mixture_4d_logpdf(samples)
 
     return log_likelihood
 

--- a/tests/integration_tests/python/test_smc_generic_temper_multivariate_gaussian.py
+++ b/tests/integration_tests/python/test_smc_generic_temper_multivariate_gaussian.py
@@ -122,7 +122,7 @@ def test_smc_generic_temper_multivariate_gaussian(
 def target_density(self, samples):  # pylint: disable=unused-argument
     """Returns the log likelihood of samples with 4D Gaussian distribution."""
     samples = np.atleast_2d(samples)
-    log_likelihood = gaussian_4d_logpdf(samples).reshape(-1, 1)
+    log_likelihood = gaussian_4d_logpdf(samples)
 
     return log_likelihood
 

--- a/tests/unit_tests/models/test_bayesian_mf_gaussian_likelihood.py
+++ b/tests/unit_tests/models/test_bayesian_mf_gaussian_likelihood.py
@@ -323,7 +323,7 @@ def test_evaluate_mf_likelihood(default_mf_likelihood, mocker):
     assert distribution_mock.logpdf.call_count == diff_mat.shape[0]
 
     # test logpdf output and input
-    np.testing.assert_array_equal(log_lik_mf, np.array([[1], [1]]))
+    np.testing.assert_array_equal(log_lik_mf, np.array([1, 1]))
 
 
 def test_grad(default_mf_likelihood):


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Why is this change required? What problem does it solve?
-->
This PR changes the shape of `log_likelihood` arrays to `(n_samples,)` instead of `(n_samples, 1)` in the `SequentialMonteCarloIterator` and `MetropolisHastingsIterator`. Also, the patched log-likelihoods for testing now have the shape `(n_samples,)`.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests:
-->
* Closes #50
* Blocks
* Is blocked by
* Follows
* Precedes
* Related to
* Part of
* Composed of

## How Has This Been Tested?
<!--
Choose from these suggestions if applicable and fill the missing options.
Feel free to provide further information if useful or necessary.
-->

## Checklist
<!--
Go over all the following points, and put an `X` in all the boxes that apply. If you are unsure about any of these, please ask; we are here to help.
-->
- [ ] My commit messages mention the appropriate issue numbers (advised but optional).
- [ ] I mention the appropriate issue numbers in this PR.
- [ ] I updated documentation where necessary.
- [ ] I have added tests to cover my changes.

## Additional Information
<!--
Is there anything else your fellow developers need to know in evaluating this pull request?
Feel free to add supplementary material here (e.g. screen output, log files, screenshots)
-->

## Interested Parties
<!--
If there's anyone you think should be looped in on this pull request, feel free to @mention them here. In particular, @mention possible reviewers as well as the maintainers of all the files you've touched.
-->

Possible reviewers:

Other interested parties:
