### PR TITLE
refactor: simplify 4C links

### DIFF
--- a/.github/workflows/tests_local.yml
+++ b/.github/workflows/tests_local.yml
@@ -31,9 +31,7 @@ jobs:
           sudo apt-get install -y rsync
       - name: Create links to 4C
         run: |
-          ln -s /home/user/4C/build/4C config/4C
-          ln -s /home/user/4C/build/post_ensight config/post_ensight
-          ln -s /home/user/4C/build/post_processor config/post_processor
+          ln -s /home/user/4C/build/ config/4C_build
       - name: Create Python environment
         id: environment
         uses: ./.github/actions/create_python_environment

--- a/tests/README.md
+++ b/tests/README.md
@@ -37,5 +37,5 @@ In QUEENS, tests are organized using pytest markers. This allows you to run all 
 ### :four_leaf_clover: Integration tests with 4C
 For the integration tests in QUEENS that require the multiphysics simulation framework [4C](https://github.com/4C-multiphysics/4C), the user needs to create a **symbolic link** to the 4C-executable and store it under `<queens-base-dir>/config`:
 ```
-ln -s <path-to-4C> <queens-base-dir>/config/4C
+ln -s <path-to-4C-build-directory> <queens-base-dir>/config/4C_build
 ```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -236,9 +236,10 @@ def fixture_config_dir():
 @pytest.fixture(name="fourc_link_paths", scope="session")
 def fixture_fourc_link_paths(config_dir):
     """Set symbolic links for 4C on testing machine."""
-    fourc = config_dir / "4C"
-    post_ensight = config_dir / "post_ensight"
-    post_processor = config_dir / "post_processor"
+    fourc_build_dir = config_dir / "4C_build"
+    fourc = fourc_build_dir / "4C"
+    post_ensight = fourc_build_dir / "post_ensight"
+    post_processor = fourc_build_dir / "post_processor"
     return fourc, post_ensight, post_processor
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,6 @@
 import getpass
 import logging
 import socket
-from pathlib import Path
 from time import perf_counter
 
 import numpy as np
@@ -27,7 +26,6 @@ from queens.global_settings import GlobalSettings
 from queens.utils import config_directories
 from queens.utils.logger_settings import reset_logging
 from queens.utils.path_utils import relative_path_from_queens, relative_path_from_source
-from test_utils.integration_tests import fourc_build_paths_from_home
 
 _logger = logging.getLogger(__name__)
 
@@ -241,12 +239,6 @@ def fixture_fourc_link_paths(config_dir):
     post_ensight = fourc_build_dir / "post_ensight"
     post_processor = fourc_build_dir / "post_processor"
     return fourc, post_ensight, post_processor
-
-
-@pytest.fixture(name="fourc_build_paths_for_gitlab_runner", scope="session")
-def fixture_fourc_build_paths_for_gitlab_runner():
-    """4C build paths on testing machine."""
-    return fourc_build_paths_from_home(Path.home())
 
 
 @pytest.fixture(name="example_simulator_fun_dir", scope="session")

--- a/tests/integration_tests/fourc/conftest.py
+++ b/tests/integration_tests/fourc/conftest.py
@@ -89,13 +89,10 @@ def fixture_setup_symbolic_links_fourc(fourc_link_paths, fourc_build_paths_for_g
         raise FileNotFoundError(
             "Please make sure to make the missing executable available under the given "
             "path OR\n"
-            "make sure the symbolic link under the config directory points to an "
-            "existing file! \n"
-            "You can create the necessary symbolic links on Linux via:\n"
+            "make sure the symbolic link in the config directory points to the build directory of "
+            "4C! \n"
+            "You can create the necessary symbolic link on Linux via:\n"
             "-------------------------------------------------------------------------\n"
-            "ln -s <path/to/fourc> <QUEENS_BaseDir>/config/4C\n"
-            "ln -s <path/to/post_ensight> <QUEENS_BaseDir>/config/post_ensight\n"
-            "ln -s <path/to/post_processor> <QUEENS_BaseDir>/config/post_processor\n"
+            "ln -s <path-to-4C-build-directory> <queens-base-dir>/config/4C_build\n"
             "-------------------------------------------------------------------------\n"
-            "...and similar for the other links."
         ) from error

--- a/tests/integration_tests/fourc/conftest.py
+++ b/tests/integration_tests/fourc/conftest.py
@@ -18,72 +18,37 @@ import pytest
 
 
 @pytest.fixture(name="setup_symbolic_links_fourc", autouse=True)
-def fixture_setup_symbolic_links_fourc(fourc_link_paths, fourc_build_paths_for_gitlab_runner):
+def fixture_setup_symbolic_links_fourc(fourc_link_paths):
     """Set-up of 4C symbolic links.
 
     Args:
-        fourc_link_paths (Path): destination for symbolic links to executables
-        fourc_build_paths_for_gitlab_runner (Path): Several paths that are needed to build symbolic
-                                                links to executables
+        fourc_link_paths (Path): Symbolic links to 4C executables.
     """
-    (
-        dst_fourc,
-        dst_post_ensight,
-        dst_post_processor,
-    ) = fourc_link_paths
-
     (
         fourc,
         post_ensight,
         post_processor,
-    ) = fourc_build_paths_for_gitlab_runner
+    ) = fourc_link_paths
+
     # check if symbolic links are existent
     try:
-        # create link to default 4C executable location if no link is available
-        if not dst_fourc.is_symlink():
-            if not fourc.is_file():
-                raise FileNotFoundError(
-                    f"Failed to create link to default 4C location.\n"
-                    f"No 4C found under default location:\n"
-                    f"\t{fourc}\n"
-                )
-            dst_fourc.symlink_to(fourc)
-        # create link to default post_ensight location if no link is available
-        if not dst_post_ensight.is_symlink():
-            if not post_ensight.is_file():
-                raise FileNotFoundError(
-                    f"Failed to create link to default post_ensight location.\n"
-                    f"No post_ensight found under default location:\n"
-                    f"\t{post_ensight}\n"
-                )
-            dst_post_ensight.symlink_to(post_ensight)
-        # create link to default post_processor location if no link is available
-        if not dst_post_processor.is_symlink():
-            if not post_processor.is_file():
-                raise FileNotFoundError(
-                    f"Failed to create link to default post_processor location.\n"
-                    f"No post_processor found under default location:\n"
-                    f"\t{post_processor}\n"
-                )
-            dst_post_processor.symlink_to(post_processor)
-
         # check if existing link to fourc works and points to a valid file
-        if not dst_fourc.resolve().exists():
+        if not fourc.resolve().exists():
             raise FileNotFoundError(
-                f"The following link seems to be dead: {dst_fourc}\n"
-                f"It points to (non-existing): {dst_fourc.resolve()}\n"
+                f"The following link seems to be dead: {fourc}\n"
+                f"It points to (non-existing): {fourc.resolve()}\n"
             )
         # check if existing link to post_ensight works and points to a valid file
-        if not dst_post_ensight.resolve().exists():
+        if not post_ensight.resolve().exists():
             raise FileNotFoundError(
-                f"The following link seems to be dead: {dst_post_ensight}\n"
-                f"It points to: {dst_post_ensight.resolve()}\n"
+                f"The following link seems to be dead: {post_ensight}\n"
+                f"It points to: {post_ensight.resolve()}\n"
             )
         # check if existing link to post_processor works and points to a valid file
-        if not dst_post_processor.resolve().exists():
+        if not post_processor.resolve().exists():
             raise FileNotFoundError(
-                f"The following link seems to be dead: {dst_post_processor}\n"
-                f"It points to: {dst_post_processor.resolve()}\n"
+                f"The following link seems to be dead: {post_processor}\n"
+                f"It points to: {post_processor.resolve()}\n"
             )
     except FileNotFoundError as error:
         raise FileNotFoundError(


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Why is this change required? What problem does it solve?
-->
Similar to the suggestion in MR [!741](https://gitlab.lrz.de/queens_community/queens/-/merge_requests/741), this PR simplifies the symbolic link setup to the 4C executables. Instead of 3 individual links to the executables, only one symbolic link to the build folder has to be created.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests:
-->
* Closes
* Blocks
* Is blocked by
* Follows
* Precedes
* Related to
* Part of
* Composed of

## How Has This Been Tested?
<!--
Choose from these suggestions if applicable and fill the missing options.
Feel free to provide further information if useful or necessary.
-->

## Checklist
<!--
Go over all the following points, and put an `X` in all the boxes that apply. If you are unsure about any of these, please ask; we are here to help.
-->
- [ ] My commit messages mention the appropriate issue numbers (advised but optional).
- [ ] I mention the appropriate issue numbers in this PR.
- [ ] I updated documentation where necessary.
- [ ] I have added tests to cover my changes.

## Additional Information
<!--
Is there anything else your fellow developers need to know in evaluating this pull request?
Feel free to add supplementary material here (e.g. screen output, log files, screenshots)
-->

## Interested Parties
<!--
If there's anyone you think should be looped in on this pull request, feel free to @mention them here. In particular, @mention possible reviewers as well as the maintainers of all the files you've touched.
-->

Possible reviewers:

Other interested parties:
