### PR TITLE
Load gcc-13-2-0 in jobscript files and modify sample array in the grid iterator

### DIFF
--- a/queens/drivers/function.py
+++ b/queens/drivers/function.py
@@ -102,6 +102,10 @@ class Function(Driver):
                     gradient = np.expand_dims(gradient, axis=0)
                 return result, gradient
             # here no gradient return
+            # take scalars and convert them to numpy floats
+            if not isinstance(result_array, np.floating):
+                result_array = np.float64(result_array)
+
             if not result_array.shape:
                 result_array = np.expand_dims(result_array, axis=0)
             return result_array, None

--- a/queens/iterators/grid.py
+++ b/queens/iterators/grid.py
@@ -155,7 +155,9 @@ class Grid(Iterator):
                 )
 
         grid_coords = np.meshgrid(*grid_point_list)
-        self.samples = np.empty([np.prod(self.num_grid_points_per_axis), self.num_parameters])
+        self.samples = np.empty(
+            [np.prod(self.num_grid_points_per_axis), self.num_parameters], dtype=object
+        )
         for i in range(self.num_parameters):
             self.samples[:, i] = grid_coords[i].flatten()
 
@@ -165,6 +167,11 @@ class Grid(Iterator):
 
     def post_run(self):
         """Analyze the results."""
+        # convert samples array (if provided) from general object to float for
+        # visualization
+        if self.samples is not None:
+            self.samples = self.samples.astype(float)
+
         if self.result_description is not None:
             results = process_outputs(self.output, self.result_description, self.samples)
             if self.result_description["write_results"]:

--- a/templates/jobscripts/fourc_bruteforce.sh
+++ b/templates/jobscripts/fourc_bruteforce.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 module load mpi/openmpi/gcc/4.1.5
+module load gcc/13-2-0
 ##########################################
 #                                        #
 #  Specify your paths                    #

--- a/templates/jobscripts/fourc_thought.sh
+++ b/templates/jobscripts/fourc_thought.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 source /etc/profile
 module load mpi/openmpi-4.1.5
+module load gcc/13-2-0
 ##########################################
 #                                        #
 #  Specify your paths                    #

--- a/tests/unit_tests/iterators/test_grid.py
+++ b/tests/unit_tests/iterators/test_grid.py
@@ -42,6 +42,15 @@ def fixture_grid_dict_two():
     return grid_dict_dummy
 
 
+@pytest.fixture(name="grid_dict_mixed_data_types")
+def fixture_grid_dict_mixed_data_types():
+    """A grid dictionary with two axes."""
+    axis_description_1 = {"num_grid_points": 5, "axis_type": "lin", "data_type": "FLOAT"}
+    axis_description_2 = {"num_grid_points": 2, "axis_type": "lin", "data_type": "INT"}
+    grid_dict_dummy = {"x1": axis_description_1, "x2": axis_description_2}
+    return grid_dict_dummy
+
+
 @pytest.fixture(name="grid_dict_three")
 def fixture_grid_dict_three():
     """A grid dictionary with three axes."""
@@ -87,6 +96,16 @@ def fixture_expected_samples_two():
     x2 = np.linspace(-2, 2, 5)
     x1, x2 = np.meshgrid(x1, x2)
     samples = np.array([x1.flatten(), x2.flatten()]).T
+    return samples
+
+
+@pytest.fixture(name="expected_samples_mixed_datatypes")
+def fixture_expected_samples_mixed_data_types():
+    """Expected samples for two parameters(different datatypes: float/int)."""
+    x1 = np.linspace(-2, 2, 5)
+    x2 = np.array([-2, 2], dtype=int)
+    x1, x2 = np.meshgrid(x1, x2)
+    samples = np.array([x1.flatten(), x2.flatten()], dtype="object").T
     return samples
 
 
@@ -204,6 +223,29 @@ def test_pre_run_two(
     )
     grid_iterator.pre_run()
     np.testing.assert_array_equal(grid_iterator.samples, expected_samples_two)
+
+
+def test_pre_run_mixed_data_types(
+    grid_dict_mixed_data_types,
+    parameters_two,
+    expected_samples_mixed_datatypes,
+    default_model,
+    global_settings,
+):
+    """Test the pre_run method for two parameters (float and int)."""
+    grid_iterator = Grid(
+        model=default_model,
+        parameters=parameters_two,
+        global_settings=global_settings,
+        result_description={},
+        grid_design=grid_dict_mixed_data_types,
+    )
+    grid_iterator.pre_run()
+
+    # assert if the columns possess the required datatypes and if the
+    # sample arrays match
+    assert grid_iterator.samples.dtype == object
+    np.testing.assert_array_equal(grid_iterator.samples, expected_samples_mixed_datatypes)
 
 
 def test_pre_run_three(


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Why is this change required? What problem does it solve?
-->
First, the `4C` cluster tests currently fail with the library error: `/lib/x86_64-linux-gnu/libstdc++.so.6: version GLIBCXX_3.4.32 not found`. This PR fixes this error by loading `gcc-13-2-0` from within the jobscript templates (tested on the LNM cluster `thought`). It remains to be investigated whether multi-node `4C` simulations require an alternative module loading approach.

Second, while attempting to inject an integer (`data_type: INT`) into the `4C` input file using the `GridIterator`, I discovered that currently a float is inserted (3.0000 instead of 3) instead. For some parameters, such as e.g., indices of material lines, this becomes problematic as `4C` does not read the number properly. To address this, I set the data type for the sample array of the iterator above to `object`, which preserves the integer (3) instead of float (3.0000) for now.  I am aware that this solution is suboptimal - however, `ndarray` objects can only have a single data type and a better solution may require a more detailed rearrangement of data. Consequently, the added unit test can only test if we really have data type `object` and may not be required in the commit. This second point is more of a draft/proposal - I can certainly convert it to an issue if that makes more sense.
## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests:
-->
* Closes
* Blocks
* Is blocked by
* Follows
* Precedes
* Related to
* Part of
* Composed of

## How Has This Been Tested?
<!--
Choose from these suggestions if applicable and fill the missing options.
Feel free to provide further information if useful or necessary.
-->

## Checklist
<!--
Go over all the following points, and put an `X` in all the boxes that apply. If you are unsure about any of these, please ask; we are here to help.
-->
- [X] My commit messages mention the appropriate issue numbers (advised but optional).
- [X] I mention the appropriate issue numbers in this PR.
- [X] I updated documentation where necessary.
- [X] I have added tests to cover my changes.

## Additional Information
<!--
Is there anything else your fellow developers need to know in evaluating this pull request?
Feel free to add supplementary material here (e.g. screen output, log files, screenshots)
-->

## Interested Parties
<!--
If there's anyone you think should be looped in on this pull request, feel free to @mention them here. In particular, @mention possible reviewers as well as the maintainers of all the files you've touched.
-->

Possible reviewers:

Other interested parties:
