### PR TITLE
ci: try to save some space

### DIFF
--- a/.github/workflows/tests_local.yml
+++ b/.github/workflows/tests_local.yml
@@ -32,6 +32,11 @@ jobs:
       - name: Create links to 4C
         run: |
           ln -s /home/user/4C/build/ config/4C_build
+      - name: Delete unnecessary 4C docker image stuff
+        run: |
+          rm -rf /home/user/4C/.git
+          find /home/user/4C -mindepth 1 -maxdepth 1 -type d -not -name build -exec rm -rf '{}' \;
+          sudo apt-get clean
       - name: Create Python environment
         id: environment
         uses: ./.github/actions/create_python_environment


### PR DESCRIPTION
## Description and Context
The 4C docker image we use is already quite big. Since there is a maximum of 10GB, due to conda packages it might be possible that we run into no space left on device errors. This simple hack should free a bit of space in the hope it works for  #132 

## Related Issues and Pull Requests

* Closes
* Blocks
* Is blocked by
* Follows
* Precedes
* Related to
* Part of
* Composed of

## How Has This Been Tested?

## Checklist

- [ ] My commit messages mention the appropriate issue numbers (advised but optional).
- [ ] I mention the appropriate issue numbers in this PR.
- [ ] I updated documentation where necessary.
- [ ] I have added tests to cover my changes.

## Additional Information


## Interested Parties
@danielwolff1

Possible reviewers:

Other interested parties:
