### PR TITLE
refactor(fourc_mc_tests): convert dat to yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       # Run the linter.
       # Needs to placed before black, isort, and other formatters
       - id: ruff
-        args: [ --fix ]
+        args: [--fix]
   - repo: local
     hooks:
       - id: trailing-whitespace
@@ -27,7 +27,7 @@ repos:
       - id: check-license-header
         name: check for correct license header
         entry: licenseheaders
-        args: ["-t", "license_header.tmpl", '--files']
+        args: ["-t", "license_header.tmpl", "--files"]
         language: python
         types: ["python"]
         pass_filenames: true
@@ -40,7 +40,7 @@ repos:
       - id: commitizen
         name: commitizen
         entry: cz
-        args: ['check', '--commit-msg-file', '.git/COMMIT_EDITMSG']
+        args: ["check", "--commit-msg-file", ".git/COMMIT_EDITMSG"]
         pass_filenames: false
         language: system
         stages: [commit-msg, manual]
@@ -65,7 +65,7 @@ repos:
         args:
           - > # This is needed to lint the jinja templates
             -d={extends: default, rules: {braces: {max-spaces-inside: 1}
-            , brackets: disable, document-start: disable}}
+            , brackets: disable, document-start: disable, "line-length": {"max": 100}}}
           - -f=colored
         language: python
         types: ["yaml"]

--- a/tests/input_files/third_party/fourc/solid_runtime_hex8.4C.yaml
+++ b/tests/input_files/third_party/fourc/solid_runtime_hex8.4C.yaml
@@ -1,0 +1,83 @@
+TITLE: |
+  This is a simple test that tests the extrapolation of stresses from Gauss points to nodes for a
+  hex8 discretization. Tested date: 12.03.2025
+PROBLEM TYPE:
+  PROBLEMTYPE: "Structure"
+IO:
+  OUTPUT_SPRING: true
+  STRUCT_STRESS: "Cauchy"
+  STRUCT_STRAIN: "Yes"
+  VERBOSITY: "standard"
+IO/RUNTIME VTK OUTPUT:
+  INTERVAL_STEPS: 1
+  OUTPUT_DATA_FORMAT: "ascii"
+IO/RUNTIME VTK OUTPUT/STRUCTURE:
+  OUTPUT_STRUCTURE: true
+  DISPLACEMENT: true
+  STRESS_STRAIN: true
+SOLVER 1:
+  SOLVER: "Superlu"
+  NAME: "Structure_Solver"
+STRUCTURAL DYNAMIC:
+  INT_STRATEGY: "Standard"
+  DYNAMICTYPE: "Statics"
+  TIMESTEP: 0.5
+  NUMSTEP: 2
+  MAXTIME: 1
+  TOLDISP: 1e-09
+  TOLRES: 1e-09
+  LOADLIN: true
+  LINEAR_SOLVER: 1
+STRUCT NOX/Printing:
+  Inner Iteration: false
+  Outer Iteration StatusTest: false
+MATERIALS:
+  - MAT: 1
+    MAT_Struct_StVenantKirchhoff:
+      YOUNG: 100
+      NUE: 0
+      DENS: 0
+FUNCT1:
+  - COMPONENT: 0
+    SYMBOLIC_FUNCTION_OF_SPACE_TIME: (1+{{ parameter_1 }}*y+{{ parameter_2 }}*z)*t
+DESIGN SURF NEUMANN CONDITIONS:
+  - E: 2
+    NUMDOF: 6
+    ONOFF: [1, 0, 0, 0, 0, 0]
+    VAL: [10, 0, 0, 0, 0, 0]
+    FUNCT: [1, 0, 0, 0, 0, 0]
+DESIGN SURF DIRICH CONDITIONS:
+  - E: 1
+    NUMDOF: 3
+    ONOFF: [1, 1, 1]
+    VAL: [0, 0, 0]
+    FUNCT: [0, 0, 0]
+PROBLEM SIZE:
+  ELEMENTS: 2
+  NODES: 12
+  MATERIALS: 9999
+DSURF-NODE TOPOLOGY:
+  - NODE 3 DSURFACE 1
+  - NODE 1 DSURFACE 1
+  - NODE 4 DSURFACE 1
+  - NODE 2 DSURFACE 1
+  - NODE 10 DSURFACE 2
+  - NODE 12 DSURFACE 2
+  - NODE 9 DSURFACE 2
+  - NODE 11 DSURFACE 2
+NODE COORDS:
+  - NODE 1 COORD 0.0 0.0 0.0
+  - NODE 2 COORD 0.0 1.0 0.0
+  - NODE 3 COORD 0.0 0.0 1.0
+  - NODE 4 COORD 0.0 1.0 1.0
+  - NODE 5 COORD 1.0 0.0 0.0
+  - NODE 6 COORD 1.0 1.0 0.0
+  - NODE 7 COORD 1.0 0.0 1.0
+  - NODE 8 COORD 1.0 1.0 1.0
+  - NODE 9 COORD 2.0 0.0 0.0
+  - NODE 10 COORD 2.0 1.0 0.0
+  - NODE 11 COORD 2.0 0.0 1.0
+  - NODE 12 COORD 2.0 1.0 1.0
+STRUCTURE ELEMENTS:
+  - 1 SOLID HEX8 1 5 6 2 3 7 8 4 MAT 1 KINEM nonlinear
+  - 2 SOLID HEX8 5 9 10 6 7 11 12 8 MAT 1 KINEM nonlinear

--- a/tests/integration_tests/cluster/test_fourc_mc_cluster.py
+++ b/tests/integration_tests/cluster/test_fourc_mc_cluster.py
@@ -120,7 +120,7 @@ class TestDaskCluster:
             fourc_example_expected_output (np.ndarray): Expected output for the MC samples
             global_settings (GlobalSettings): object containing experiment name and tmp_path
         """
-        fourc_input_file_template = third_party_inputs / "fourc" / "solid_runtime_hex8.dat"
+        fourc_input_file_template = third_party_inputs / "fourc" / "solid_runtime_hex8.4C.yaml"
 
         # Parameters
         parameter_1 = Uniform(lower_bound=0.0, upper_bound=1.0)

--- a/tests/integration_tests/fourc/test_fourc_mc.py
+++ b/tests/integration_tests/fourc/test_fourc_mc.py
@@ -40,7 +40,7 @@ def test_fourc_mc(
 ):
     """Test simple 4C run."""
     # generate json input file from template
-    fourc_input_file_template = third_party_inputs / "fourc" / "solid_runtime_hex8.dat"
+    fourc_input_file_template = third_party_inputs / "fourc" / "solid_runtime_hex8.4C.yaml"
     fourc_executable, _, _ = fourc_link_paths
 
     # Parameters


### PR DESCRIPTION
## Description and Context
Convert one of the 4C tests types to yaml. The other one can't be transformed since the external geometry still relies on dat

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests:
-->
* Closes
* Blocks
* Is blocked by
* Follows
* Precedes
* Related to
* Part of
* Composed of

## How Has This Been Tested?
<!--
Choose from these suggestions if applicable and fill the missing options.
Feel free to provide further information if useful or necessary.
-->

## Checklist
<!--
Go over all the following points, and put an `X` in all the boxes that apply. If you are unsure about any of these, please ask; we are here to help.
-->
- [ ] My commit messages mention the appropriate issue numbers (advised but optional).
- [ ] I mention the appropriate issue numbers in this PR.
- [ ] I updated documentation where necessary.
- [ ] I have added tests to cover my changes.

## Additional Information
<!--
Is there anything else your fellow developers need to know in evaluating this pull request?
Feel free to add supplementary material here (e.g. screen output, log files, screenshots)
-->

## Interested Parties
<!--
If there's anyone you think should be looped in on this pull request, feel free to @mention them here. In particular, @mention possible reviewers as well as the maintainers of all the files you've touched.
-->

Possible reviewers:

Other interested parties:
