### PR TITLE
Simplify base directory structure

### DIFF
--- a/queens/utils/config_directories.py
+++ b/queens/utils/config_directories.py
@@ -22,7 +22,6 @@ from queens.utils.path import create_folder_if_not_existent
 _logger = logging.getLogger(__name__)
 
 BASE_DATA_DIR = "queens-experiments"
-BASE_DATA_DIR_FOR_TESTS = "queens-tests"
 
 
 def base_directory():

--- a/queens/utils/config_directories.py
+++ b/queens/utils/config_directories.py
@@ -21,9 +21,8 @@ from queens.utils.path import create_folder_if_not_existent
 
 _logger = logging.getLogger(__name__)
 
-BASE_DATA_DIR = "queens-simulation-data"
-EXPERIMENTS_BASE_FOLDER_NAME = "experiments"
-TESTS_BASE_FOLDER_NAME = "tests"
+BASE_DATA_DIR = "queens-experiments"
+BASE_DATA_DIR_FOR_TESTS = "queens-tests"
 
 
 def base_directory():
@@ -33,22 +32,13 @@ def base_directory():
     return base_dir
 
 
-def experiments_base_directory():
-    """Hold all experiment data on the computing machine."""
-    base_dir = base_directory()
-    experiments_base_dir = base_dir / EXPERIMENTS_BASE_FOLDER_NAME
-    create_directory(experiments_base_dir)
-    return experiments_base_dir
-
-
 def experiment_directory(experiment_name):
     """Directory for data of a specific experiment on the computing machine.
 
     Args:
         experiment_name (str): Experiment name
     """
-    experiments_base_dir = experiments_base_directory()
-    experiment_dir = experiments_base_dir / experiment_name
+    experiment_dir = base_directory() / experiment_name
     create_directory(experiment_dir)
     return experiment_dir
 

--- a/queens/utils/config_directories.py
+++ b/queens/utils/config_directories.py
@@ -25,7 +25,25 @@ BASE_DATA_DIR = "queens-experiments"
 
 
 def base_directory():
-    """Hold all queens related data."""
+    """Holds all queens experiments.
+
+    The base directory holds individual folders for each queens experiment on the compute machine.
+    Per default, it is located and structured as follows::
+
+        $HOME/queens-experiments
+          ├── experiment_name_1
+          ├── experiment_name_2
+
+    For remote cluster test runs, a separate base directory structure is used::
+
+        $HOME/queens-tests
+          ├── pytest-0
+          │   ├── test_name_1
+          │   └── test_name_2
+          ├── pytest-1
+              ├── test_name_1
+              └── test_name_2
+    """
     base_dir = Path().home() / BASE_DATA_DIR
     create_directory(base_dir)
     return base_dir
@@ -33,6 +51,8 @@ def base_directory():
 
 def experiment_directory(experiment_name):
     """Directory for data of a specific experiment on the computing machine.
+
+    Refer to base_directory() for an explanation of the directory structure.
 
     Args:
         experiment_name (str): Experiment name

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -185,31 +185,6 @@ def fixture_global_mock_local_base_dir(monkeypatch, tmp_path):
     _logger.debug("local base dir is mocked to: %s", config_directories.base_directory())
 
 
-@pytest.fixture(name="mock_value_experiments_base_folder_name", scope="session")
-def fixture_mock_value_experiments_base_folder_name():
-    """Value to mock the experiments base folder name."""
-    return "pytest"
-
-
-@pytest.fixture(name="global_mock_experiments_base_folder_name", autouse=True)
-def fixture_global_mock_experiments_base_folder_name(
-    mock_value_experiments_base_folder_name, monkeypatch
-):
-    """Mock the name of the folders containing experiments in base directory.
-
-    Note that locally, this adds on top of the
-    global_mock_local_base_dir
-    """
-    monkeypatch.setattr(
-        config_directories, "EXPERIMENTS_BASE_FOLDER_NAME", mock_value_experiments_base_folder_name
-    )
-    _logger.debug("Mocking of EXPERIMENTS_BASE_FOLDER_NAME was successful.")
-    _logger.debug(
-        "EXPERIMENTS_BASE_FOLDER_NAME is mocked to: %s",
-        config_directories.EXPERIMENTS_BASE_FOLDER_NAME,
-    )
-
-
 @pytest.fixture(name="inputdir", scope="session")
 def fixture_inputdir():
     """Return the path to the json input-files of the function test."""

--- a/tests/integration_tests/cluster/test_fourc_mc_cluster.py
+++ b/tests/integration_tests/cluster/test_fourc_mc_cluster.py
@@ -28,7 +28,6 @@ from queens.iterators.monte_carlo import MonteCarlo
 from queens.main import run_iterator
 from queens.models.simulation import Simulation
 from queens.parameters.parameters import Parameters
-from queens.utils import config_directories
 from queens.utils.io import load_result
 from tests.integration_tests.conftest import (  # BRUTEFORCE_CLUSTER_TYPE,
     CHARON_CLUSTER_TYPE,
@@ -56,7 +55,7 @@ class TestDaskCluster:
 
     def pytest_base_directory_on_cluster(self):
         """Remote directory containing several pytest runs."""
-        return f"$HOME/{config_directories.BASE_DATA_DIR_FOR_TESTS}"
+        return "$HOME/queens-tests"
 
     @pytest.fixture(name="queens_base_directory_on_cluster")
     def fixture_queens_base_directory_on_cluster(self, pytest_id):

--- a/tests/integration_tests/cluster/test_fourc_mc_cluster.py
+++ b/tests/integration_tests/cluster/test_fourc_mc_cluster.py
@@ -54,6 +54,15 @@ class TestDaskCluster:
     for these tests.
     """
 
+    def experiment_dir_on_cluster(self):
+        """Remote experiment path."""
+        return f"$HOME/{config_directories.BASE_DATA_DIR_FOR_TESTS}"
+
+    @pytest.fixture(name="patched_base_directory")
+    def fixture_patched_base_directory(self, pytest_id):
+        """Path of the tests on the remote cluster."""
+        return self.experiment_dir_on_cluster() + f"/{pytest_id}"
+
     @pytest.fixture(autouse=True)
     def mock_experiment_dir(self, monkeypatch, cluster_settings, patched_base_directory):
         """Mock the experiment directory on the cluster.
@@ -62,7 +71,7 @@ class TestDaskCluster:
         NOTE: It is necessary to mock the whole experiment_directory method.
         Otherwise, the mock is not loaded properly remote.
         This is in contrast to the local mocking where it suffices to mock
-        config_directories.EXPERIMENTS_BASE_FOLDER_NAME.
+        config_directories.BASE_DATA_DIR.
         Note that we also rely on this local mock here!
         """
 
@@ -82,17 +91,6 @@ class TestDaskCluster:
             cluster_settings["user"],
             cluster_settings["host"],
         )
-
-    def experiment_dir_on_cluster(self):
-        """Remote experiment path."""
-        return (
-            f"$HOME/{config_directories.BASE_DATA_DIR}/{config_directories.TESTS_BASE_FOLDER_NAME}"
-        )
-
-    @pytest.fixture(name="patched_base_directory")
-    def fixture_patched_base_directory(self, pytest_id):
-        """Path of the tests on the remote cluster."""
-        return self.experiment_dir_on_cluster() + f"/{pytest_id}"
 
     def test_fourc_mc_cluster(
         self,

--- a/tests/integration_tests/cluster/test_fourc_mc_cluster.py
+++ b/tests/integration_tests/cluster/test_fourc_mc_cluster.py
@@ -69,8 +69,10 @@ class TestDaskCluster:
         """
         return self.pytest_base_directory_on_cluster() + f"/{pytest_id}"
 
-    @pytest.fixture(autouse=True)
-    def mock_experiment_dir(self, monkeypatch, cluster_settings, queens_base_directory_on_cluster):
+    @pytest.fixture(name="mock_experiment_dir", autouse=True)
+    def fixture_mock_experiment_dir(
+        self, monkeypatch, cluster_settings, queens_base_directory_on_cluster
+    ):
         """Mock the experiment directory of a test on the cluster.
 
         NOTE: It is necessary to mock the whole experiment_directory method.

--- a/tests/integration_tests/cluster/test_fourc_mc_cluster.py
+++ b/tests/integration_tests/cluster/test_fourc_mc_cluster.py
@@ -195,7 +195,7 @@ class TestDaskCluster:
         command = (
             "find "
             + str(self.pytest_base_directory_on_cluster())
-            + " -mtime +7 -mindepth 1 -maxdepth 1 -type d -exec rm -rv {} \\;"
+            + " -mindepth 1 -maxdepth 1 -mtime +7 -type d -exec rm -rv {} \\;"
         )
         result = remote_connection.run(command, in_stream=False)
         _logger.debug("Deleting old simulation data:\n%s", result.stdout)


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Why is this change required? What problem does it solve?
-->
This PR simplifies the base directory structure.

Previously the base directory was located at `$HOME/queens-simulation-data`.
This folder contained a subdirectory named `experiments`, which in turn housed separate folders for each user-conducted experiment.
A second folder named `tests` was created on the remote base directory when running the cluster tests.
Once upon a time, when we still used the Singularity-based workflow, the base directory also contained Singularity containers.

The old structure was thus:
```
$HOME/queens-simulation-data 
  ├── singularity_image_1.simg
  ├── singularity_image_2.simg
  ├── experiments
  │   ├── my_experiment_1
  │   ├── my_experiment_2
  └── tests
      ├── pytest-0
      │   ├── my_test_1
      │   └── my_test_2
      ├── pytest-1
          ├── my_test_1
          └── my_test_2
```

However, since the discontinuation of the Singularity-based workflow, the only exception is now the cluster test runs, where files are not written into the `$HOME/queens-simulation-data/experiments` folder.  

**The extra nesting adds unnecessary complexity to the folder structure.** 

For this reason, we decided (see [developer meeting](https://github.com/queens-py/queens-meetings/issues/4)) to restructure the layout as follows:
	•	A renamed base directory, `$HOME/queens-experiments`, will hold individual folders for each experiment.
	•	For cluster test runs, a separate base directory called `$HOME/queens-tests` will be used.
```
$HOME/queens-experiments
  ├── my_experiment_1
  ├── my_experiment_2

(only on remote for cluster tests):
$HOME/queens-tests
  ├── pytest-0
  │   ├── my_test_1
  │   └── my_test_2
  ├── pytest-1
      ├── my_test_1
      └── my_test_2
```

This change simplifies the directory structure and navigation within.


## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests:
-->
* Closes
* Blocks
* Is blocked by
* Follows
* Precedes
* Related to
* Part of
* Composed of

## How Has This Been Tested?
<!--
Choose from these suggestions if applicable and fill the missing options.
Feel free to provide further information if useful or necessary.
-->

## Checklist
<!--
Go over all the following points, and put an `X` in all the boxes that apply. If you are unsure about any of these, please ask; we are here to help.
-->
- [ ] My commit messages mention the appropriate issue numbers (advised but optional).
- [ ] I mention the appropriate issue numbers in this PR.
- [ ] I updated documentation where necessary.
- [ ] I have added tests to cover my changes.

## Additional Information
<!--
Is there anything else your fellow developers need to know in evaluating this pull request?
Feel free to add supplementary material here (e.g. screen output, log files, screenshots)
-->

## Interested Parties
<!--
If there's anyone you think should be looped in on this pull request, feel free to @mention them here. In particular, @mention possible reviewers as well as the maintainers of all the files you've touched.
-->

Possible reviewers:

Other interested parties:
