### PR TITLE
docs: use the entire width

### DIFF
--- a/doc/source/_static/custom.css
+++ b/doc/source/_static/custom.css
@@ -19,3 +19,13 @@ a:hover {
     text-decoration: underline;
     /* Underline links when howering. */
 }
+
+.bd-main .bd-content .bd-article-container {
+    max-width: 100%;
+    /* Use the entire width */
+}
+
+.bd-page-width {
+    max-width: 100%;
+    /* Use the entire width */
+}


### PR DESCRIPTION
## Description and Context:<br> What and Why?
This PR changes the Sphinx documentation setup to increase the width of the content. This makes the documentation a bit more readable, especially if we have long variable names and/or Python code. (thanks @sebproell for reminding me of this)

Current: 
![image](https://github.com/user-attachments/assets/a5f26d66-8cf4-4cfb-95bc-2ff7cf609df1)

Proposed change:
![image](https://github.com/user-attachments/assets/264a8495-954b-48d5-be18-153ac896a299)

@sbrandstaeter @BishrMaradni, I think this also makes the tutorial more readable.

## Related Issues and Pull Requests
* Closes
* Related to #160

## Interested Parties