### PR TITLE
Introduce logger on dask workers

### DIFF
--- a/src/queens/data_processors/csv_file.py
+++ b/src/queens/data_processors/csv_file.py
@@ -67,6 +67,8 @@ class CsvFile(DataProcessor):
         file_name_identifier=None,
         file_options_dict=None,
         files_to_be_deleted_regex_lst=None,
+        worker_log_level=logging.INFO,
+        write_worker_log_files=True,
     ):
         """Instantiate data processor class for csv data.
 
@@ -99,6 +101,10 @@ class CsvFile(DataProcessor):
             files_to_be_deleted_regex_lst (lst): List with paths to files that should be deleted.
                                                  The paths can contain regex expressions.
 
+            worker_log_level (int | str): Logging level used on the worker (default: "INFO")
+            write_worker_log_files (bool): Control writing of worker logs to files (one per job)
+                                           (default: True)
+
         Returns:
             Instance of CsvFile class
         """
@@ -106,6 +112,8 @@ class CsvFile(DataProcessor):
             file_name_identifier=file_name_identifier,
             file_options_dict=file_options_dict,
             files_to_be_deleted_regex_lst=files_to_be_deleted_regex_lst,
+            worker_log_level=worker_log_level,
+            write_worker_log_files=write_worker_log_files,
         )
 
         header_row = file_options_dict.get("header_row")

--- a/src/queens/data_processors/csv_file.py
+++ b/src/queens/data_processors/csv_file.py
@@ -108,6 +108,7 @@ class CsvFile(DataProcessor):
         Returns:
             Instance of CsvFile class
         """
+        # pylint: disable=duplicate-code
         super().__init__(
             file_name_identifier=file_name_identifier,
             file_options_dict=file_options_dict,

--- a/src/queens/data_processors/numpy_file.py
+++ b/src/queens/data_processors/numpy_file.py
@@ -49,6 +49,7 @@ class NumpyFile(DataProcessor):
             write_worker_log_files (bool): Control writing of worker logs to files (one per job)
                                            (default: True)
         """
+        # pylint: disable=duplicate-code
         super().__init__(
             file_name_identifier=file_name_identifier,
             file_options_dict=file_options_dict,

--- a/src/queens/data_processors/numpy_file.py
+++ b/src/queens/data_processors/numpy_file.py
@@ -33,6 +33,8 @@ class NumpyFile(DataProcessor):
         file_name_identifier=None,
         file_options_dict=None,
         files_to_be_deleted_regex_lst=None,
+        worker_log_level=logging.INFO,
+        write_worker_log_files=True,
     ):
         """Instantiate data processor class for numpy binary data.
 
@@ -43,11 +45,16 @@ class NumpyFile(DataProcessor):
             file_options_dict (dict): Dictionary with read-in options for the file
             files_to_be_deleted_regex_lst (lst): List with paths to files that should be deleted.
                                                  The paths can contain regex expressions.
+            worker_log_level (int | str): Logging level used on the worker (default: "INFO")
+            write_worker_log_files (bool): Control writing of worker logs to files (one per job)
+                                           (default: True)
         """
         super().__init__(
             file_name_identifier=file_name_identifier,
             file_options_dict=file_options_dict,
             files_to_be_deleted_regex_lst=files_to_be_deleted_regex_lst,
+            worker_log_level=worker_log_level,
+            write_worker_log_files=write_worker_log_files,
         )
 
     def get_raw_data_from_file(self, file_path):

--- a/src/queens/data_processors/pvd_file.py
+++ b/src/queens/data_processors/pvd_file.py
@@ -45,6 +45,8 @@ class PvdFile(DataProcessor):
         time_steps=None,
         block=0,
         point_data=True,
+        worker_log_level=logging.INFO,
+        write_worker_log_files=True,
     ):
         """Instantiate data processor class for pvd data extraction.
 
@@ -60,11 +62,16 @@ class PvdFile(DataProcessor):
             block (int, optional): Considered block of MultiBlock data set (first block by default)
             point_data (bool, optional): Whether to extract point data (True) or cell data (False).
                                          Defaults to point data.
+            worker_log_level (int | str): Logging level used on the worker (default: "INFO")
+            write_worker_log_files (bool): Control writing of worker logs to files (one per job)
+                                           (default: True)
         """
         super().__init__(
             file_name_identifier=file_name_identifier,
             file_options_dict=file_options_dict,
             files_to_be_deleted_regex_lst=files_to_be_deleted_regex_lst,
+            worker_log_level=worker_log_level,
+            write_worker_log_files=write_worker_log_files,
         )
         self.field_name = field_name
         if time_steps is None:

--- a/src/queens/data_processors/pvd_file.py
+++ b/src/queens/data_processors/pvd_file.py
@@ -66,6 +66,7 @@ class PvdFile(DataProcessor):
             write_worker_log_files (bool): Control writing of worker logs to files (one per job)
                                            (default: True)
         """
+        # pylint: disable=duplicate-code
         super().__init__(
             file_name_identifier=file_name_identifier,
             file_options_dict=file_options_dict,

--- a/src/queens/data_processors/txt_file.py
+++ b/src/queens/data_processors/txt_file.py
@@ -78,6 +78,7 @@ class TxtFile(DataProcessor):
             write_worker_log_files (bool): Control writing of worker logs to files (one per job)
                                            (default: True)
         """
+        # pylint: disable=duplicate-code
         super().__init__(
             file_name_identifier=file_name_identifier,
             file_options_dict=file_options_dict,

--- a/src/queens/data_processors/txt_file.py
+++ b/src/queens/data_processors/txt_file.py
@@ -54,6 +54,8 @@ class TxtFile(DataProcessor):
         logger_prefix=r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} - "
         r"queens\.drivers\.driver_\d* - INFO -",
         max_file_size_in_mega_byte=200,
+        worker_log_level=logging.INFO,
+        write_worker_log_files=True,
     ):
         """Instantiate data processor class for txt data.
 
@@ -72,11 +74,16 @@ class TxtFile(DataProcessor):
             max_file_size_in_mega_byte (int):       Upper limit of the file size to be read into
                                                     memory in megabyte (MB). See comment above on
                                                     Potential Improvement.
+            worker_log_level (int | str): Logging level used on the worker (default: "INFO")
+            write_worker_log_files (bool): Control writing of worker logs to files (one per job)
+                                           (default: True)
         """
         super().__init__(
             file_name_identifier=file_name_identifier,
             file_options_dict=file_options_dict,
             files_to_be_deleted_regex_lst=files_to_be_deleted_regex_lst,
+            worker_log_level=worker_log_level,
+            write_worker_log_files=write_worker_log_files,
         )
         self.remove_logger_prefix_from_raw_data = remove_logger_prefix_from_raw_data
         self.logger_prefix = logger_prefix

--- a/src/queens/drivers/_driver.py
+++ b/src/queens/drivers/_driver.py
@@ -80,8 +80,11 @@ class Driver(metaclass=abc.ABCMeta):
         Returns:
             Result and potentially the gradient
         """
-        job_dir, output_dir, output_file, log_file = self._manage_paths(job_id, experiment_dir)
-        worker_log_dir = output_dir if self.write_worker_log_files else None
+        _, worker_log_dir = (
+            self._manage_paths(job_id, experiment_dir)
+            if self.write_worker_log_files
+            else (None, None)
+        )
         self.logger_on_worker = setup_logger_on_worker(
             name=type(self).__name__, log_dir=worker_log_dir, level=self.worker_log_level
         )
@@ -92,10 +95,6 @@ class Driver(metaclass=abc.ABCMeta):
             num_procs,
             experiment_dir,
             experiment_name,
-            job_dir,
-            output_dir,
-            output_file,
-            log_file,
         )
 
     @abc.abstractmethod
@@ -106,10 +105,6 @@ class Driver(metaclass=abc.ABCMeta):
         num_procs,
         experiment_dir,
         experiment_name,
-        job_dir,
-        output_dir,
-        output_file,
-        log_file,
     ):
         """Abstract method for driver run.
 
@@ -119,15 +114,12 @@ class Driver(metaclass=abc.ABCMeta):
             num_procs (int): number of processors
             experiment_dir (Path): Path to QUEENS experiment directory.
             experiment_name (str): name of QUEENS experiment.
-            job_dir (Path): Path to job directory.
-            output_dir (Path): Path to output directory.
-            output_file (Path): Path to output file(s).
-            log_file (Path): Path to log file.
 
         Returns:
             Result and potentially the gradient
         """
 
+    @final
     def _manage_paths(self, job_id, experiment_dir):
         """Manage paths for driver run.
 
@@ -145,8 +137,4 @@ class Driver(metaclass=abc.ABCMeta):
         output_dir = job_dir / "output"
         create_directory(output_dir)
 
-        output_prefix = "output"
-        output_file = output_dir / output_prefix
-        log_file = output_dir / (output_prefix + ".log")
-
-        return job_dir, output_dir, output_file, log_file
+        return job_dir, output_dir

--- a/src/queens/drivers/_driver.py
+++ b/src/queens/drivers/_driver.py
@@ -19,6 +19,7 @@ import logging
 from pathlib import Path
 from typing import final
 
+from queens.utils.config_directories import create_directory, job_directory
 from queens.utils.logger_settings import setup_logger_on_worker
 
 _logger = logging.getLogger(__name__)
@@ -140,9 +141,9 @@ class Driver(metaclass=abc.ABCMeta):
             output_file (Path): Path to output file(s).
             log_file (Path): Path to log file.
         """
-        job_dir = experiment_dir / str(job_id)
+        job_dir = job_directory(experiment_dir, job_id)
         output_dir = job_dir / "output"
-        output_dir.mkdir(parents=True, exist_ok=True)
+        create_directory(output_dir)
 
         output_prefix = "output"
         output_file = output_dir / output_prefix

--- a/src/queens/drivers/function.py
+++ b/src/queens/drivers/function.py
@@ -42,7 +42,7 @@ class Function(Driver):
         function,
         external_python_module_function=None,
         worker_log_level=logging.INFO,
-        write_worker_log_files=True,
+        write_worker_log_files=False,
     ):
         """Initialize Function object.
 

--- a/src/queens/drivers/function.py
+++ b/src/queens/drivers/function.py
@@ -41,6 +41,8 @@ class Function(Driver):
         parameters,
         function,
         external_python_module_function=None,
+        worker_log_level=logging.INFO,
+        write_worker_log_files=True,
     ):
         """Initialize Function object.
 
@@ -48,8 +50,15 @@ class Function(Driver):
             parameters (Parameters): Parameters object
             function (callable, str): Function or name of example function provided by QUEENS
             external_python_module_function (Path | str): Path to external module with function
+            worker_log_level (int | str): Logging level used on the worker (default: "INFO")
+            write_worker_log_files (bool): Control writing of worker logs to files (one per job)
+                                           (default: True)
         """
-        super().__init__(parameters=parameters)
+        super().__init__(
+            parameters=parameters,
+            worker_log_level=worker_log_level,
+            write_worker_log_files=write_worker_log_files,
+        )
         if external_python_module_function is None:
             if isinstance(function, str):
                 # Try to load existing simulator functions

--- a/src/queens/drivers/function.py
+++ b/src/queens/drivers/function.py
@@ -112,7 +112,7 @@ class Function(Driver):
 
         return reshaped_output_function
 
-    def run(self, sample, job_id, num_procs, experiment_dir, experiment_name):
+    def _run(self, sample, job_id, num_procs, experiment_dir, experiment_name):
         """Run the driver.
 
         Args:

--- a/src/queens/drivers/function.py
+++ b/src/queens/drivers/function.py
@@ -112,15 +112,30 @@ class Function(Driver):
 
         return reshaped_output_function
 
-    def _run(self, sample, job_id, num_procs, experiment_dir, experiment_name):
+    def _run(
+        self,
+        sample,
+        job_id,
+        num_procs,
+        experiment_dir,
+        experiment_name,
+        job_dir,
+        output_dir,
+        output_file,
+        log_file,
+    ):
         """Run the driver.
 
         Args:
             sample (dict): Dict containing sample
             job_id (int): Job ID
             num_procs (int): number of processors
-            experiment_name (str): name of QUEENS experiment.
             experiment_dir (Path): Path to QUEENS experiment directory.
+            experiment_name (str): name of QUEENS experiment.
+            job_dir (Path): Path to job directory.
+            output_dir (Path): Path to output directory.
+            output_file (Path): Path to output file(s).
+            log_file (Path): Path to log file.
 
         Returns:
             Result and potentially the gradient

--- a/src/queens/drivers/function.py
+++ b/src/queens/drivers/function.py
@@ -128,10 +128,6 @@ class Function(Driver):
         num_procs,
         experiment_dir,
         experiment_name,
-        job_dir,
-        output_dir,
-        output_file,
-        log_file,
     ):
         """Run the driver.
 
@@ -141,10 +137,6 @@ class Function(Driver):
             num_procs (int): number of processors
             experiment_dir (Path): Path to QUEENS experiment directory.
             experiment_name (str): name of QUEENS experiment.
-            job_dir (Path): Path to job directory.
-            output_dir (Path): Path to output directory.
-            output_file (Path): Path to output file(s).
-            log_file (Path): Path to log file.
 
         Returns:
             Result and potentially the gradient

--- a/src/queens/drivers/jobscript.py
+++ b/src/queens/drivers/jobscript.py
@@ -97,6 +97,8 @@ class Jobscript(Driver):
         jobscript_file_name="jobscript.sh",
         extra_options=None,
         raise_error_on_jobscript_failure=True,
+        worker_log_level=logging.INFO,
+        write_worker_log_files=True,
     ):
         """Initialize Jobscript object.
 
@@ -113,8 +115,16 @@ class Jobscript(Driver):
             extra_options (dict, opt): Extra options to inject into jobscript template.
             raise_error_on_jobscript_failure (bool, opt): Whether to raise an error for a non-zero
                                                           jobscript exit code.
+            worker_log_level (int | str): Logging level used on the worker (default: "INFO")
+            write_worker_log_files (bool): Control writing of worker logs to files (one per job)
+                                           (default: True)
         """
-        super().__init__(parameters=parameters, files_to_copy=files_to_copy)
+        super().__init__(
+            parameters=parameters,
+            files_to_copy=files_to_copy,
+            worker_log_level=worker_log_level,
+            write_worker_log_files=write_worker_log_files,
+        )
         self.input_templates = self.create_input_templates_dict(input_templates)
         self.jobscript_template = self.get_read_in_jobscript_template(jobscript_template)
         self.files_to_copy.extend(self.input_templates.values())

--- a/src/queens/drivers/jobscript.py
+++ b/src/queens/drivers/jobscript.py
@@ -187,7 +187,7 @@ class Jobscript(Driver):
 
         return jobscript_template
 
-    def run(self, sample, job_id, num_procs, experiment_dir, experiment_name):
+    def _run(self, sample, job_id, num_procs, experiment_dir, experiment_name):
         """Run the driver.
 
         Args:
@@ -239,7 +239,7 @@ class Jobscript(Driver):
             self._run_executable(job_id, execute_cmd)
 
         with metadata.time_code("data_processing"):
-            results = self._get_results(output_dir)
+            results = self._get_results(output_dir, experiment_dir)
             metadata.outputs = results
 
         return results
@@ -293,11 +293,12 @@ class Jobscript(Driver):
                 f"{process_returncode}.",
             )
 
-    def _get_results(self, output_dir):
+    def _get_results(self, output_dir, experiment_dir=None):
         """Get results from driver run.
 
         Args:
             output_dir (Path): Path to output directory.
+            experiment_dir (Path | None): Path to QUEENS experiment directory.
 
         Returns:
             result (np.array): Result from the driver run.
@@ -305,13 +306,13 @@ class Jobscript(Driver):
         """
         result = None
         if self.data_processor:
-            result = self.data_processor.get_data_from_file(output_dir)
-            _logger.debug("Got result: %s", result)
+            result = self.data_processor.get_data_from_file(output_dir, experiment_dir)
+            self.logger_on_dask_worker.info("Got result: %s", result)
 
         gradient = None
         if self.gradient_data_processor:
-            gradient = self.gradient_data_processor.get_data_from_file(output_dir)
-            _logger.debug("Got gradient: %s", gradient)
+            gradient = self.gradient_data_processor.get_data_from_file(output_dir, experiment_dir)
+            self.logger_on_dask_worker.info("Got gradient: %s", gradient)
         return result, gradient
 
     def prepare_input_files(self, sample_dict, experiment_dir, input_files):

--- a/src/queens/drivers/jobscript.py
+++ b/src/queens/drivers/jobscript.py
@@ -187,7 +187,18 @@ class Jobscript(Driver):
 
         return jobscript_template
 
-    def _run(self, sample, job_id, num_procs, experiment_dir, experiment_name):
+    def _run(
+        self,
+        sample,
+        job_id,
+        num_procs,
+        experiment_dir,
+        experiment_name,
+        job_dir,
+        output_dir,
+        output_file,
+        log_file,
+    ):
         """Run the driver.
 
         Args:
@@ -195,14 +206,16 @@ class Jobscript(Driver):
             job_id (int): Job ID.
             num_procs (int): Number of processors.
             experiment_dir (Path): Path to QUEENS experiment directory.
-            experiment_name (str): Name of QUEENS experiment.
+            experiment_name (str): name of QUEENS experiment.
+            job_dir (Path): Path to job directory.
+            output_dir (Path): Path to output directory.
+            output_file (Path): Path to output file(s).
+            log_file (Path): Path to log file.
 
         Returns:
             Result and potentially the gradient.
         """
-        job_dir, output_dir, output_file, input_files, log_file = self._manage_paths(
-            job_id, experiment_dir
-        )
+        input_files = self._manage_input_files(job_dir)
 
         sample_dict = self.parameters.sample_as_dict(sample)
 
@@ -239,39 +252,26 @@ class Jobscript(Driver):
             self._run_executable(job_id, execute_cmd)
 
         with metadata.time_code("data_processing"):
-            results = self._get_results(output_dir, experiment_dir)
+            results = self._get_results(output_dir)
             metadata.outputs = results
 
         return results
 
-    def _manage_paths(self, job_id, experiment_dir):
+    def _manage_input_files(self, job_dir):
         """Manage paths for driver run.
 
         Args:
-            job_id (int): Job ID.
-            experiment_dir (Path): Path to QUEENS experiment directory.
+            job_dir (Path): Path to job directory.
 
         Returns:
-            job_dir (Path): Path to job directory.
-            output_dir (Path): Path to output directory.
-            output_file (Path): Path to output file(s).
             input_files (dict): Dict with name and path of the input file(s).
-            log_file (Path): Path to log file.
         """
-        job_dir = experiment_dir / str(job_id)
-        output_dir = job_dir / "output"
-        output_dir.mkdir(parents=True, exist_ok=True)
-
-        output_prefix = "output"
-        output_file = output_dir / output_prefix
-        log_file = output_dir / (output_prefix + ".log")
-
         input_files = {}
         for input_template_name, input_template_path in self.input_templates.items():
             input_file_str = input_template_name + "".join(input_template_path.suffixes)
             input_files[input_template_name] = job_dir / input_file_str
 
-        return job_dir, output_dir, output_file, input_files, log_file
+        return input_files
 
     def _run_executable(self, job_id, execute_cmd):
         """Run executable.
@@ -293,12 +293,11 @@ class Jobscript(Driver):
                 f"{process_returncode}.",
             )
 
-    def _get_results(self, output_dir, experiment_dir=None):
+    def _get_results(self, output_dir):
         """Get results from driver run.
 
         Args:
             output_dir (Path): Path to output directory.
-            experiment_dir (Path | None): Path to QUEENS experiment directory.
 
         Returns:
             result (np.array): Result from the driver run.
@@ -306,13 +305,13 @@ class Jobscript(Driver):
         """
         result = None
         if self.data_processor:
-            result = self.data_processor.get_data_from_file(output_dir, experiment_dir)
-            self.logger_on_dask_worker.info("Got result: %s", result)
+            result = self.data_processor.get_data_from_file(output_dir)
+            self.logger_on_worker.info("Got result: %s", result)
 
         gradient = None
         if self.gradient_data_processor:
-            gradient = self.gradient_data_processor.get_data_from_file(output_dir, experiment_dir)
-            self.logger_on_dask_worker.info("Got gradient: %s", gradient)
+            gradient = self.gradient_data_processor.get_data_from_file(output_dir)
+            self.logger_on_worker.info("Got gradient: %s", gradient)
         return result, gradient
 
     def prepare_input_files(self, sample_dict, experiment_dir, input_files):

--- a/src/queens/drivers/mpi.py
+++ b/src/queens/drivers/mpi.py
@@ -14,6 +14,8 @@
 #
 """Convenience wrapper around Jobscript Driver."""
 
+import logging
+
 from queens.drivers.jobscript import Jobscript
 from queens.utils.logger_settings import log_init_args
 
@@ -35,6 +37,8 @@ class Mpi(Jobscript):
         data_processor=None,
         gradient_data_processor=None,
         mpi_cmd="/usr/bin/mpirun --bind-to none",
+        worker_log_level=logging.INFO,
+        write_worker_log_files=True,
     ):
         """Initialize MPI object.
 
@@ -46,6 +50,9 @@ class Mpi(Jobscript):
             data_processor (obj, opt): instance of data processor class
             gradient_data_processor (obj, opt): instance of data processor class for gradient data
             mpi_cmd (str, opt): mpi command
+            worker_log_level (int | str): Logging level used on the worker (default: "INFO")
+            write_worker_log_files (bool): Control writing of worker logs to files (one per job)
+                                           (default: True)
         """
         # pylint: disable=duplicate-code
         extra_options = {
@@ -60,4 +67,6 @@ class Mpi(Jobscript):
             data_processor=data_processor,
             gradient_data_processor=gradient_data_processor,
             extra_options=extra_options,
+            worker_log_level=worker_log_level,
+            write_worker_log_files=write_worker_log_files,
         )

--- a/src/queens/models/adjoint.py
+++ b/src/queens/models/adjoint.py
@@ -17,7 +17,7 @@
 import logging
 
 from queens.models.simulation import Simulation
-from queens.utils.config_directories import current_job_directory
+from queens.utils.config_directories import job_directory
 from queens.utils.io import write_to_csv
 from queens.utils.logger_settings import log_init_args
 
@@ -77,7 +77,7 @@ class Adjoint(Simulation):
 
         # write adjoint data for each sample to adjoint files in old job directories
         for job_id, grad_objective in zip(last_job_ids, upstream_gradient):
-            job_dir = current_job_directory(experiment_dir, job_id)
+            job_dir = job_directory(experiment_dir, job_id)
             adjoint_file_path = job_dir.joinpath(self.adjoint_file)
             write_to_csv(adjoint_file_path, grad_objective.reshape(1, -1))
 

--- a/src/queens/utils/config_directories.py
+++ b/src/queens/utils/config_directories.py
@@ -73,6 +73,21 @@ def experiment_directory(
     return experiment_dir
 
 
+def logging_directory_on_dask_worker(experiment_dir):
+    """Directory for log-files of dask workers.
+
+    This is called on the Dask Worker thus the experiment directory should lready exist
+    and can be passed directly.
+
+
+    Args:
+        experiment_dir (Path): Directory for data of a specific experiment on the computing machine.
+    """
+    log_dir = experiment_dir / "dask_workers_logs"
+    create_directory(log_dir)
+    return log_dir
+
+
 def create_directory(dir_path: str | Path) -> None:
     """Create a directory either local or remote.
 

--- a/src/queens/utils/config_directories.py
+++ b/src/queens/utils/config_directories.py
@@ -73,21 +73,6 @@ def experiment_directory(
     return experiment_dir
 
 
-def logging_directory_on_dask_worker(experiment_dir):
-    """Directory for log-files of dask workers.
-
-    This is called on the Dask Worker thus the experiment directory should lready exist
-    and can be passed directly.
-
-
-    Args:
-        experiment_dir (Path): Directory for data of a specific experiment on the computing machine.
-    """
-    log_dir = experiment_dir / "dask_workers_logs"
-    create_directory(log_dir)
-    return log_dir
-
-
 def create_directory(dir_path: str | Path) -> None:
     """Create a directory either local or remote.
 

--- a/src/queens/utils/config_directories.py
+++ b/src/queens/utils/config_directories.py
@@ -83,8 +83,8 @@ def create_directory(dir_path: str | Path) -> None:
     create_folder_if_not_existent(dir_path)
 
 
-def current_job_directory(experiment_dir: Path, job_id: int) -> Path:
-    """Directory of the latest submitted job.
+def job_directory(experiment_dir: Path, job_id: int) -> Path:
+    """Directory of a specific job.
 
     Args:
         experiment_dir: Experiment directory
@@ -108,9 +108,9 @@ def job_dirs_in_experiment_dir(experiment_dir: Path | str) -> list[Path]:
     """
     experiment_dir = Path(experiment_dir)
     job_directories = []
-    for job_directory in experiment_dir.iterdir():
-        if job_directory.is_dir() and job_directory.name.isdigit():
-            job_directories.append(job_directory)
+    for job_dir in experiment_dir.iterdir():
+        if job_dir.is_dir() and job_dir.name.isdigit():
+            job_directories.append(job_dir)
 
     # Sort the jobs directories
     return sorted(job_directories, key=lambda x: int(x.name))

--- a/src/queens/utils/logger_settings.py
+++ b/src/queens/utils/logger_settings.py
@@ -281,16 +281,18 @@ def log_init_args(method: Callable[P, None]) -> Callable[P, None]:
     return wrapper
 
 
-def setup_logger_on_worker(name="worker", log_dir=None, level=logging.INFO):
+def setup_logger_on_worker(
+    name: str = "worker", log_dir: None | Path = None, level: int = logging.INFO
+) -> logging.Logger:
     """Setup a logger on a scheduler's worker.
 
     Args:
-        name (str): Name of the logger.
-        log_dir (Path): Path to the directory for the log file.
-        level (int): Logging level.
+        name: Name of the logger.
+        log_dir: Path to the directory for the log file.
+        level: Logging level.
 
     Returns:
-        logger (logging.Logger): Logger instance.
+        logger: Logger instance.
     """
     logger = logging.getLogger(name)
 

--- a/src/queens/utils/logger_settings.py
+++ b/src/queens/utils/logger_settings.py
@@ -21,6 +21,9 @@ import sys
 from pathlib import Path
 from typing import Any, Callable, ParamSpec
 
+from dask.distributed import get_worker
+
+from queens.utils.config_directories import logging_directory_on_dask_worker
 from queens.utils.printing import get_str_table
 
 LIBRARY_LOGGER_NAME = "queens"
@@ -279,3 +282,45 @@ def log_init_args(method: Callable[P, None]) -> Callable[P, None]:
         method(*args, **kwargs)
 
     return wrapper
+
+
+def setup_logger_on_dask_worker(name="worker", experiment_dir=None, level=logging.INFO):
+    """Setup a logger on a dask worker.
+
+    Args:
+        name (str): Name of the logger.
+        experiment_dir (Path): Path to the experiment directory.
+        level (int): Logging level.
+
+    Returns:
+        logger (logging.Logger): Logger instance.
+    """
+    logger = logging.getLogger(name)
+
+    if logger.hasHandlers():
+        return logger  # Already configured (avoid duplicate handlers)
+
+    logger.setLevel(level)
+    formatter = NewLineFormatter(
+        "%(asctime)s %(name)-12s %(levelname)-8s %(message)s", datefmt="%m-%d %H:%M"
+    )
+
+    if experiment_dir is not None:
+        log_dir = logging_directory_on_dask_worker(experiment_dir)
+
+        try:
+            worker = get_worker()
+            log_file = log_dir / f"{worker.name}.log"
+        except ValueError:
+            # Not inside a Dask worker — maybe running locally
+            log_file = log_dir / f"{name}_client.log"
+
+        file_handler = logging.FileHandler(log_file)
+        file_handler.setFormatter(formatter)
+        logger.addHandler(file_handler)
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(formatter)
+    logger.addHandler(stream_handler)
+
+    return logger

--- a/src/queens_interfaces/fourc/driver.py
+++ b/src/queens_interfaces/fourc/driver.py
@@ -14,6 +14,8 @@
 #
 """Driver to run 4C."""
 
+import logging
+
 from queens.drivers.jobscript import Jobscript
 from queens.utils.logger_settings import log_init_args
 
@@ -41,6 +43,8 @@ class Fourc(Jobscript):
         post_processor="",
         post_options="",
         mpi_cmd="/usr/bin/mpirun --bind-to none",
+        worker_log_level=logging.INFO,
+        write_worker_log_files=True,
     ):
         """Initialize Fourc object.
 
@@ -54,6 +58,9 @@ class Fourc(Jobscript):
             post_processor (path, opt): path to post_processor
             post_options (str, opt): options for post-processing
             mpi_cmd (str, opt): mpi command
+            worker_log_level (int | str): Logging level used on the worker (default: "INFO")
+            write_worker_log_files (bool): Control writing of worker logs to files (one per job)
+                                           (default: True)
         """
         # pylint: disable=duplicate-code
         extra_options = {
@@ -70,4 +77,6 @@ class Fourc(Jobscript):
             data_processor=data_processor,
             gradient_data_processor=gradient_data_processor,
             extra_options=extra_options,
+            worker_log_level=worker_log_level,
+            write_worker_log_files=write_worker_log_files,
         )


### PR DESCRIPTION
## Description and Context:<br> What and Why?
<!--
Provide a brief and concise description of your proposed change.
In particular: Why is this change required? What problem does it solve? Is this a breaking change?
-->
### Summary

This PR introduces logging support for code running inside Dask workers, specifically within the `driver.run` and `dataprocessor.get_data_from_file` methods, as discussed in issue #165. This should enable debugging these methods even on an HPC cluster.

### Motivation

Currently, there's no logging when these methods are executed on a Dask worker, making it difficult to debug or monitor behavior during distributed execution.

### What's Proposed

- A dedicated logger (`self.logger_on_dask_worker`) is initialized inside the above methods if it doesn't already exist.
- This allows logging within Dask workers to be captured reliably.

### Logging Setup

- Logs are written **both to file and to the standard stream**.
- **One log file per worker** is used. If a worker restarts and gets the same ID (e.g. due to `restart_worker=True`), it reuses the same log file.
- **Log files are stored under** `<experiment_dir>/dask_workers_logs`.
- The **stream output** might also be captured by job schedulers like SLURM, depending on the environment.

### Notes

This PR is meant to establish a **solid initial foundation** for Dask-side logging. While the current solution may not cover all edge cases or logging best practices, it's a step in the right direction and open for future improvements. Feedback on design and setup is welcome.

## Related Issues and Pull Requests
<!--
If applicable: how is this pull request related to other open issues or pull requests?
-->
* Closes #165
* Related to

## Interested Parties
<!--
If there's anyone you think should be looped in on this pull request,
feel free to @mention them here!
-->
