### PR TITLE
Switch to client.gather 

### DIFF
--- a/queens/schedulers/_dask.py
+++ b/queens/schedulers/_dask.py
@@ -14,20 +14,60 @@
 #
 """QUEENS dask scheduler parent class."""
 
-import abc
 import logging
+import random
 import time
+from typing import TYPE_CHECKING
 
 import numpy as np
-import tqdm
-from dask.distributed import as_completed
+from dask.distributed import progress
+from distributed import WorkerPlugin
 
 from queens.schedulers._scheduler import Scheduler
 from queens.utils.printing import get_str_table
 
+if TYPE_CHECKING:
+    from typing import Any
+
+    from dask.typing import Key
+    from distributed.worker import Worker
+    from distributed.worker_state_machine import TaskStateState as WorkerTaskStateState
 _logger = logging.getLogger(__name__)
 
 SHUTDOWN_CLIENTS = []
+
+
+class ShutdownAfterFirstTask(WorkerPlugin):
+    """Shutdown a worker after the first task is finished."""
+
+    def setup(self, worker):
+        """Setup the worker plugin.
+
+        Run when the plugin is attached to a worker.
+
+        Args:
+            worker (Worker): The worker that has this plugin.
+        """
+        self.worker = worker  # pylint: disable=attribute-defined-outside-init
+        self.has_shutdown = False  # pylint: disable=attribute-defined-outside-init
+
+    def transition(self, key, start, finish, **kwargs):
+        """Called when task changes its state.
+
+        Args:
+            key (Key): Key of the task.
+            start (WorkerTaskStateState): Start state of the transition. One of waiting, ready,
+                                          executing, long-running, memory, error.
+            finish (WorkerTaskStateState): Final state of the transition.
+            kwargs (Any): More options passed when transitioning
+        """
+        if start == "executing" and finish == "memory" and not self.has_shutdown:
+            self.has_shutdown = True  # pylint: disable=attribute-defined-outside-init
+
+            async def shutdown():
+                await self.worker.close_gracefully(reason=f"Shutdown after task {key}")
+
+            self.worker.loop.call_later(2, shutdown)
 
 
 class Dask(Scheduler):
@@ -69,6 +109,11 @@ class Dask(Scheduler):
         self.num_procs = num_procs
         self.client = client
         self.restart_workers = restart_workers
+
+        # Register this plugin on all workers
+        if self.restart_workers:
+            self.client.register_plugin(ShutdownAfterFirstTask(), name="shutdown_after_first")
+
         global SHUTDOWN_CLIENTS  # pylint: disable=global-variable-not-assigned
         SHUTDOWN_CLIENTS.append(client.shutdown)
 
@@ -83,15 +128,14 @@ class Dask(Scheduler):
         Returns:
             result_dict (dict): Dictionary containing results
         """
-        if self.restart_workers:
-            # This is necessary, because the subprocess in the driver does not get killed
-            # sometimes when the worker is restarted.
-            def run_driver(*args, **kwargs):
-                time.sleep(5)
-                return driver.run(*args, **kwargs)
 
-        else:
-            run_driver = driver.run
+        # the initial batch can overwhelm the hardware of a cluster
+        # by starting many jobs at the same time
+        # -> introduce a random wait time for jobs to spread the load
+        def run_driver(*args, **kwargs):
+            random_wait_time = random.uniform(3, 7)
+            time.sleep(random_wait_time)
+            return driver.run(*args, **kwargs)
 
         if job_ids is None:
             job_ids = self.get_job_ids(len(samples))
@@ -108,44 +152,36 @@ class Dask(Scheduler):
         # The theoretical number of sequential jobs
         num_sequential_jobs = int(np.ceil(len(samples) / self.num_jobs))
 
-        results = {future.key: None for future in futures}
-        with tqdm.tqdm(total=len(futures)) as progressbar:
-            for future in as_completed(futures):
-                results[future.key] = future.result()
-                progressbar.update(1)
-                if self.restart_workers:
-                    worker = list(self.client.who_has(future).values())[0]
-                    self.restart_worker(worker)
+        start_time = time.time()
+        progress(futures)
+        results_values = self.client.gather(futures)
 
-            if self.verbose:
-                elapsed_time = progressbar.format_dict["elapsed"]
-                averaged_time_per_job = elapsed_time / num_sequential_jobs
+        if self.verbose:
+            elapsed_time = time.time() - start_time
+            averaged_time_per_job = elapsed_time / num_sequential_jobs
 
-                run_time_dict = {
-                    "number of jobs": len(samples),
-                    "number of parallel jobs": self.num_jobs,
-                    "number of procs": self.num_procs,
-                    "total elapsed time": f"{elapsed_time:.3e}s",
-                    "average time per parallel job": f"{averaged_time_per_job:.3e}s",
-                }
-                _logger.info(
-                    get_str_table(
-                        f"Batch summary for jobs {min(job_ids)} - {max(job_ids)}", run_time_dict
-                    )
+            run_time_dict = {
+                "number of jobs": len(samples),
+                "number of parallel jobs": self.num_jobs,
+                "number of procs": self.num_procs,
+                "total elapsed time": f"{elapsed_time:.3e}s",
+                "average time per parallel job": f"{averaged_time_per_job:.3e}s",
+            }
+            _logger.info(
+                get_str_table(
+                    f"Batch summary for jobs {min(job_ids)} - {max(job_ids)}", run_time_dict
                 )
+            )
 
         result_dict = {"result": [], "gradient": []}
-        for result in results.values():
+        # for result in results:
+        for result in results_values:
             # We should remove this squeeze! It is only introduced for consistency with old test.
             result_dict["result"].append(np.atleast_1d(np.array(result[0]).squeeze()))
             result_dict["gradient"].append(result[1])
         result_dict["result"] = np.array(result_dict["result"])
         result_dict["gradient"] = np.array(result_dict["gradient"])
         return result_dict
-
-    @abc.abstractmethod
-    def restart_worker(self, worker):
-        """Restart a worker."""
 
     async def shutdown_client(self):
         """Shutdown the DASK client."""

--- a/queens/schedulers/cluster.py
+++ b/queens/schedulers/cluster.py
@@ -199,6 +199,7 @@ class Cluster(Dask):
             local_port_dashboard,
         )
 
+        # pylint: disable=duplicate-code
         super().__init__(
             experiment_name=experiment_name,
             experiment_dir=experiment_dir,
@@ -208,17 +209,7 @@ class Cluster(Dask):
             restart_workers=restart_workers,
             verbose=verbose,
         )
-
-    def restart_worker(self, worker):
-        """Restart a worker.
-
-        This method retires a dask worker. The Client.adapt method of dask takes cares of submitting
-        new workers subsequently.
-
-        Args:
-            worker (str, tuple): Worker to restart. This can be a worker address, name, or a both.
-        """
-        self.client.retire_workers(workers=list(worker))
+        # pylint: enable=duplicate-code
 
     def copy_files_to_experiment_dir(self, paths):
         """Copy file to experiment directory.

--- a/queens/schedulers/local.py
+++ b/queens/schedulers/local.py
@@ -54,6 +54,7 @@ class Local(Dask):
         _logger.info(
             "To view the Dask dashboard open this link in your browser: %s", client.dashboard_link
         )
+        # pylint: disable=duplicate-code
         super().__init__(
             experiment_name=experiment_name,
             experiment_dir=experiment_dir,
@@ -63,11 +64,4 @@ class Local(Dask):
             restart_workers=restart_workers,
             verbose=verbose,
         )
-
-    def restart_worker(self, worker):
-        """Restart a worker.
-
-        Args:
-            worker (str, tuple): Worker to restart. This can be a worker address, name, or a both.
-        """
-        self.client.restart_workers(workers=list(worker))
+        # pylint: enable=duplicate-code


### PR DESCRIPTION
## Description and Context:<br> What and Why?
<!--
Provide a brief and concise description of your proposed change.
In particular: Why is this change required? What problem does it solve? Is this a breaking change?
-->
### Switch to `client.gather` for Improved Task Collection Robustness

This PR replaces the current Dask task collection approach with `client.gather`, which proved significantly more robust during the *hpc.bw* project, especially when collecting results from many small tasks. The previous method occasionally led to excessive delays for lightweight tasks, despite minimal expected compute time.

#### Key Changes

- **Improved Result Collection**: Uses `client.gather` for consistent handling of both small and large tasks.
- **Worker Identification and Restart**: Since `client.gather` delays access to worker metadata until all tasks complete, a new worker restart mechanism is introduced using Dask's `WorkerPlugin`.
- **Progress Reporting**: Switched to Dask’s internal progress bar. Compatibility or parallel use with `tqdm` remains open for discussion.

This change enhances reliability in distributed task execution, particularly in high-throughput scenarios.
## Related Issues and Pull Requests
<!--
If applicable: how is this pull request related to other open issues or pull requests?
-->
* Closes
* Related to

## Interested Parties
<!--
If there's anyone you think should be looped in on this pull request,
feel free to @mention them here!
-->
