### PR TITLE
fix: lazy imports

### DIFF
--- a/src/queens/iterators/__init__.py
+++ b/src/queens/iterators/__init__.py
@@ -17,55 +17,64 @@
 Modules for parameter studies, uncertainty quantification, sensitivity
 analysis, Bayesian inverse analysis, and optimization.
 """
+from typing import TYPE_CHECKING
 
-from queens.iterators.bbvi import BBVI
-from queens.iterators.bmfia import BMFIA
-from queens.iterators.bmfmc import BMFMC
-from queens.iterators.classification import ClassificationIterator
-from queens.iterators.data import Data
-from queens.iterators.elementary_effects import ElementaryEffects
-from queens.iterators.grid import Grid
-from queens.iterators.hamiltonian_monte_carlo import HamiltonianMonteCarlo
-from queens.iterators.latin_hypercube_sampling import LatinHypercubeSampling
-from queens.iterators.least_squares import LeastSquares
-from queens.iterators.metropolis_hastings import MetropolisHastings
-from queens.iterators.metropolis_hastings_pymc import MetropolisHastingsPyMC
-from queens.iterators.monte_carlo import MonteCarlo
-from queens.iterators.nuts import NUTS
-from queens.iterators.optimization import Optimization
-from queens.iterators.points import Points
-from queens.iterators.polynomial_chaos import PolynomialChaos
-from queens.iterators.reinforcement_learning import ReinforcementLearning
-from queens.iterators.reparameteriztion_based_variational import RPVI
-from queens.iterators.sequential_monte_carlo import SequentialMonteCarlo
-from queens.iterators.sequential_monte_carlo_chopin import SequentialMonteCarloChopin
-from queens.iterators.sobol_index import SobolIndex
-from queens.iterators.sobol_index_gp_uncertainty import SobolIndexGPUncertainty
-from queens.iterators.sobol_sequence import SobolSequence
+from queens.utils.imports import import_class_from_class_module_map
 
-VALID_TYPES = {
-    "hmc": HamiltonianMonteCarlo,
-    "lhs": LatinHypercubeSampling,
-    "metropolis_hastings": MetropolisHastings,
-    "metropolis_hastings_pymc": MetropolisHastingsPyMC,
-    "monte_carlo": MonteCarlo,
-    "nuts": NUTS,
-    "optimization": Optimization,
-    "read_data_from_file": Data,
-    "elementary_effects": ElementaryEffects,
-    "polynomial_chaos": PolynomialChaos,
-    "sobol_indices": SobolIndex,
-    "sobol_indices_gp_uncertainty": SobolIndexGPUncertainty,
-    "smc": SequentialMonteCarlo,
-    "smc_chopin": SequentialMonteCarloChopin,
-    "sobol_sequence": SobolSequence,
-    "points": Points,
-    "bmfmc": BMFMC,
-    "grid": Grid,
-    "least_squares": LeastSquares,
-    "bbvi": BBVI,
-    "bmfia": BMFIA,
-    "rpvi": RPVI,
-    "classification": ClassificationIterator,
-    "reinforcement_learning": ReinforcementLearning,
+if TYPE_CHECKING:
+    from queens.iterators.bbvi import BBVI
+    from queens.iterators.bmfia import BMFIA
+    from queens.iterators.bmfmc import BMFMC
+    from queens.iterators.classification import ClassificationIterator
+    from queens.iterators.data import Data
+    from queens.iterators.elementary_effects import ElementaryEffects
+    from queens.iterators.grid import Grid
+    from queens.iterators.hamiltonian_monte_carlo import HamiltonianMonteCarlo
+    from queens.iterators.latin_hypercube_sampling import LatinHypercubeSampling
+    from queens.iterators.least_squares import LeastSquares
+    from queens.iterators.metropolis_hastings import MetropolisHastings
+    from queens.iterators.metropolis_hastings_pymc import MetropolisHastingsPyMC
+    from queens.iterators.monte_carlo import MonteCarlo
+    from queens.iterators.nuts import NUTS
+    from queens.iterators.optimization import Optimization
+    from queens.iterators.points import Points
+    from queens.iterators.polynomial_chaos import PolynomialChaos
+    from queens.iterators.reinforcement_learning import ReinforcementLearning
+    from queens.iterators.reparameteriztion_based_variational import RPVI
+    from queens.iterators.sequential_monte_carlo import SequentialMonteCarlo
+    from queens.iterators.sequential_monte_carlo_chopin import SequentialMonteCarloChopin
+    from queens.iterators.sobol_index import SobolIndex
+    from queens.iterators.sobol_index_gp_uncertainty import SobolIndexGPUncertainty
+    from queens.iterators.sobol_sequence import SobolSequence
+
+
+class_module_map = {
+    "BBVI": "bbvi",
+    "BMFIA": "bmfia",
+    "BMFMC": "bmfmc",
+    "ClassificationIterator": "classification",
+    "Data": "data",
+    "ElementaryEffects": "elementary_effects",
+    "Grid": "grid",
+    "HamiltonMonteCarlo": "hamiltonian_monte_carlo",
+    "LatinHypercubeSampling": "latin_hypercube_sampling",
+    "LeastSquares": "least_squares",
+    "MetropolisHastings": "metropolis_hastings",
+    "MetropolisHastingsPyMC": "metropolis_hastings_pymc",
+    "MonteCarlo": "monte_carlo",
+    "NUTS": "nuts",
+    "Optimization": "optimization",
+    "Points": "points",
+    "PolynomialChaos": "polynomial_chaos",
+    "ReinforcementLearning": "reinforcement_learning",
+    "RPVI": "reparameteriztion_based_variational",
+    "SequentialMonteCarlo": "sequential_monte_carlo",
+    "SequentialMonteCarloChopin": "sequential_monte_carlo_chopin",
+    "SobolIndex": "sobol_index",
+    "SobolIndexGPUncertainty": "sobol_index_gp_uncertainty",
+    "SobolSequence": "sobol_sequence",
 }
+
+
+def __getattr__(name):
+    return import_class_from_class_module_map(name, class_module_map, __name__)

--- a/src/queens/models/__init__.py
+++ b/src/queens/models/__init__.py
@@ -17,34 +17,44 @@
 Modules for multi-query mapping of inputs to outputs, such as parameter
 samples to model evaluations.
 """
+from typing import TYPE_CHECKING
 
-from queens.models.adjoint import Adjoint
-from queens.models.bmfmc import BMFMC
-from queens.models.finite_difference import FiniteDifference
-from queens.models.likelihoods.bmf_gaussian import BMFGaussian, BmfiaInterface
-from queens.models.likelihoods.gaussian import Gaussian
-from queens.models.reinforcement_learning.reinforcement_learning import ReinforcementLearning
-from queens.models.simulation import Simulation
-from queens.models.surrogates.bayesian_neural_network import GaussianBayesianNeuralNetwork
-from queens.models.surrogates.gaussian_neural_network import GaussianNeuralNetwork
-from queens.models.surrogates.gaussian_process import GaussianProcess
-from queens.models.surrogates.heteroskedastic_gaussian_process import HeteroskedasticGaussianProcess
-from queens.models.surrogates.jitted_gaussian_process import JittedGaussianProcess
-from queens.models.surrogates.variational_gaussian_process import VariationalGaussianProcess
+from queens.utils.imports import import_class_from_class_module_map
 
-VALID_TYPES = {
-    "simulation_model": Simulation,
-    "bmfmc_model": BMFMC,
-    "gaussian": Gaussian,
-    "bmf_gaussian": BMFGaussian,
-    "bmfia_interface": BmfiaInterface,
-    "differentiable_simulation_model_fd": FiniteDifference,
-    "differentiable_simulation_model_adjoint": Adjoint,
-    "heteroskedastic_gp": HeteroskedasticGaussianProcess,
-    "gp_approximation_gpflow": GaussianProcess,
-    "gaussian_bayesian_neural_network": GaussianBayesianNeuralNetwork,
-    "gp_jitted": JittedGaussianProcess,
-    "gp_approximation_gpflow_svgp": VariationalGaussianProcess,
-    "gaussian_nn": GaussianNeuralNetwork,
-    "reinforcement_learning": ReinforcementLearning,
+if TYPE_CHECKING:
+    from queens.models.adjoint import Adjoint
+    from queens.models.bmfmc import BMFMC
+    from queens.models.finite_difference import FiniteDifference
+    from queens.models.likelihoods.bmf_gaussian import BMFGaussian, BmfiaInterface
+    from queens.models.likelihoods.gaussian import Gaussian
+    from queens.models.reinforcement_learning.reinforcement_learning import ReinforcementLearning
+    from queens.models.simulation import Simulation
+    from queens.models.surrogates.bayesian_neural_network import GaussianBayesianNeuralNetwork
+    from queens.models.surrogates.gaussian_neural_network import GaussianNeuralNetwork
+    from queens.models.surrogates.gaussian_process import GaussianProcess
+    from queens.models.surrogates.heteroskedastic_gaussian_process import (
+        HeteroskedasticGaussianProcess,
+    )
+    from queens.models.surrogates.jitted_gaussian_process import JittedGaussianProcess
+    from queens.models.surrogates.variational_gaussian_process import VariationalGaussianProcess
+
+class_module_map = {
+    "Adjoint": "adjoint",
+    "BMFMC": "bmfmc",
+    "FiniteDifference": "finite_difference",
+    "BMFGaussian": "likelihoods.bmf_gaussian",
+    "BmfiaInterface": "likelihoods.bmf_gaussian.bmfia_interface",
+    "Gaussian": "likelihoods.gaussian",
+    "ReinforcementLearning": "reinforcement_learning.reinforcement_learning",
+    "Simulation": "simulation",
+    "GaussianBayesianNeuralNetwork": "likelihoods.bayesian_neural_network",
+    "GaussianNeuralNetwork": "likelihoods.gaussian_neural_network",
+    "GaussianProcess": "surrogates.gaussian_process",
+    "HeteroskedasticGaussianProcess": "surrogates.heteroskedastic_gaussian_process",
+    "JittedGaussianProcess": "surrogates.jitted_gaussian_process",
+    "VariationalGaussianProcess": "surrogates.variational_gaussian_process",
 }
+
+
+def __getattr__(name):
+    return import_class_from_class_module_map(name, class_module_map, __name__)

--- a/src/queens/models/surrogates/bayesian_neural_network.py
+++ b/src/queens/models/surrogates/bayesian_neural_network.py
@@ -15,10 +15,11 @@
 """Implementation of a Bayesian Neural Network."""
 
 import logging
-from typing import TYPE_CHECKING
 
 import numpy as np
+import tensorflow as tf
 import tensorflow_probability as tfp
+import tf_keras as keras
 
 from queens.models.surrogates._surrogate import Surrogate
 from queens.utils.configure_tensorflow import configure_keras, configure_tensorflow
@@ -29,18 +30,8 @@ _logger = logging.getLogger(__name__)
 tfd = tfp.distributions
 DenseVar = tfp.layers.DenseVariational
 
-# This allows autocomplete in the IDE
-if TYPE_CHECKING:
-    import tensorflow as tf
-    import tf_keras as keras
-else:
-    from queens.utils.imports import LazyLoader
-
-    tf = LazyLoader("tensorflow")
-    keras = LazyLoader("tf_keras")
-
-    configure_tensorflow(tf)
-    configure_keras(keras)
+configure_tensorflow(tf)
+configure_keras(keras)
 
 
 class GaussianBayesianNeuralNetwork(Surrogate):

--- a/src/queens/models/surrogates/gaussian_neural_network.py
+++ b/src/queens/models/surrogates/gaussian_neural_network.py
@@ -15,10 +15,11 @@
 """Gaussian Neural Network regression model."""
 
 import logging
-from typing import TYPE_CHECKING
 
 import numpy as np
+import tensorflow as tf
 import tensorflow_probability as tfp
+import tf_keras as keras
 
 from queens.models.surrogates._surrogate import Surrogate
 from queens.utils.configure_tensorflow import configure_keras, configure_tensorflow
@@ -28,18 +29,9 @@ from queens.utils.valid_options import get_option
 from queens.visualization.gaussian_neural_network_vis import plot_loss
 
 tfd = tfp.distributions
-# This allows autocomplete in the IDE
-if TYPE_CHECKING:
-    import tensorflow as tf
-    import tf_keras as keras
-else:
-    from queens.utils.imports import LazyLoader
 
-    tf = LazyLoader("tensorflow")
-    keras = LazyLoader("tf_keras")
-
-    configure_tensorflow(tf)
-    configure_keras(keras)
+configure_tensorflow(tf)
+configure_keras(keras)
 
 _logger = logging.getLogger(__name__)
 

--- a/src/queens/models/surrogates/gaussian_process.py
+++ b/src/queens/models/surrogates/gaussian_process.py
@@ -15,9 +15,10 @@
 """Gaussian process implementation in GPFlow."""
 
 import logging
-from typing import TYPE_CHECKING
 
+import gpflow as gpf
 import numpy as np
+import tensorflow as tf
 import tensorflow_probability as tfp
 
 from queens.models.surrogates._surrogate import Surrogate
@@ -28,17 +29,7 @@ from queens.utils.numpy_array import extract_block_diag
 
 _logger = logging.getLogger(__name__)
 
-# This allows autocomplete in the IDE
-if TYPE_CHECKING:
-    import gpflow as gpf
-    import tensorflow as tf
-else:
-    from queens.utils.imports import LazyLoader
-
-    tf = LazyLoader("tensorflow")
-    gpf = LazyLoader("gpflow")
-
-    configure_tensorflow(tf)
+configure_tensorflow(tf)
 
 
 class GaussianProcess(Surrogate):

--- a/src/queens/models/surrogates/heteroskedastic_gaussian_process.py
+++ b/src/queens/models/surrogates/heteroskedastic_gaussian_process.py
@@ -15,10 +15,12 @@
 """Implementation of a heteroskedastic Gaussian process models using GPFlow."""
 
 import logging
-from typing import TYPE_CHECKING
 
+import gpflow as gpf
 import numpy as np
+import tensorflow as tf
 import tensorflow_probability as tfp
+import tf_keras as keras
 from sklearn.cluster import KMeans
 
 from queens.models.surrogates._surrogate import Surrogate
@@ -27,20 +29,8 @@ from queens.utils.logger_settings import log_init_args
 
 _logger = logging.getLogger(__name__)
 
-# This allows autocomplete in the IDE
-if TYPE_CHECKING:
-    import gpflow as gpf
-    import tensorflow as tf
-    import tf_keras as keras
-else:
-    from queens.utils.imports import LazyLoader
-
-    tf = LazyLoader("tensorflow")
-    keras = LazyLoader("tf_keras")
-    gpf = LazyLoader("gpflow")
-
-    configure_tensorflow(tf)
-    configure_keras(keras)
+configure_tensorflow(tf)
+configure_keras(keras)
 
 
 class HeteroskedasticGaussianProcess(Surrogate):

--- a/src/queens/models/surrogates/variational_gaussian_process.py
+++ b/src/queens/models/surrogates/variational_gaussian_process.py
@@ -30,10 +30,12 @@ allowing users to easily integrate the SVGP model into their machine learning wo
 """
 
 import logging
-from typing import TYPE_CHECKING
 
+import gpflow as gpf
 import numpy as np
+import tensorflow as tf
 import tensorflow_probability as tfp
+import tf_keras as keras
 
 from queens.models.surrogates._surrogate import Surrogate
 from queens.utils.configure_tensorflow import configure_keras, configure_tensorflow
@@ -43,19 +45,8 @@ from queens.utils.numpy_array import extract_block_diag
 
 _logger = logging.getLogger(__name__)
 
-# This allows autocomplete in the IDE
-if TYPE_CHECKING:
-    import gpflow as gpf
-    import tensorflow as tf
-else:
-    from queens.utils.imports import LazyLoader
-
-    tf = LazyLoader("tensorflow")
-    keras = LazyLoader("tf_keras")
-    gpf = LazyLoader("gpflow")
-
-    configure_tensorflow(tf)
-    configure_keras(keras)
+configure_tensorflow(tf)
+configure_keras(keras)
 
 
 class VariationalGaussianProcess(Surrogate):

--- a/src/queens/utils/from_config_create.py
+++ b/src/queens/utils/from_config_create.py
@@ -22,9 +22,11 @@ from queens.distributions import VALID_TYPES as VALID_DISTRIBUTION_TYPES
 from queens.drivers import VALID_TYPES as VALID_DRIVER_TYPES
 from queens.drivers._driver import Driver
 from queens.external_geometries import VALID_TYPES as VALID_EXTERNAL_GEOMETRY_TYPES
-from queens.iterators import VALID_TYPES as VALID_ITERATOR_TYPES
+
+# from queens.iterators import VALID_TYPES as VALID_ITERATOR_TYPES
 from queens.iterators._iterator import Iterator
-from queens.models import VALID_TYPES as VALID_MODEL_TYPES
+
+# from queens.models import VALID_TYPES as VALID_MODEL_TYPES
 from queens.models.bmfmc import BMFMC
 from queens.parameters.parameters import from_config_create_parameters
 from queens.parameters.random_fields import VALID_TYPES as VALID_RANDOM_FIELD_TYPES
@@ -54,8 +56,8 @@ VALID_TYPES = {
     **VALID_EXPERIMENTAL_DATA_READER_TYPES,
     **VALID_EXTERNAL_GEOMETRY_TYPES,
     **VALID_ITERATIVE_AVERAGING_TYPES,
-    **VALID_ITERATOR_TYPES,
-    **VALID_MODEL_TYPES,
+    #    **VALID_ITERATOR_TYPES,
+    #    **VALID_MODEL_TYPES,
     **VALID_RANDOM_FIELD_TYPES,
     **VALID_SCHEDULER_TYPES,
     **VALID_STOCHASTIC_OPTIMIZER_TYPES,

--- a/src/queens/utils/gpflow_transformations.py
+++ b/src/queens/utils/gpflow_transformations.py
@@ -14,17 +14,8 @@
 #
 """Utilis for gpflow."""
 
-from typing import TYPE_CHECKING
-
+import gpflow as gpf
 from sklearn.preprocessing import StandardScaler
-
-# This allows autocomplete in the IDE
-if TYPE_CHECKING:
-    import gpflow as gpf
-else:
-    from queens.utils.imports import LazyLoader
-
-    gpf = LazyLoader("gpflow")
 
 
 def init_scaler(unscaled_data):

--- a/src/queens/utils/imports.py
+++ b/src/queens/utils/imports.py
@@ -93,31 +93,18 @@ def get_module_class(module_options, valid_types, module_type_specifier="type"):
     return module_class
 
 
-class LazyLoader:
-    """Lazy loader for modules that take long to load.
+def import_class_from_class_module_map(name, class_module_map, directory):
+    """Import class from class_module_map.
 
-    Inspired from https://stackoverflow.com/a/78312617
+    Args:
+        name (str): Name of the class.
+        class_module_map (dict): Class to module mapping.
+        directory (str): Directory of module.
+
+    Returns:
+        class (obj): Class object.
     """
-
-    def __init__(self, module_name):
-        """Initialize the loader.
-
-        Args:
-            module_name (str): name of the module to be imported
-        """
-        self._module_name = module_name
-        self._module = None
-
-    def __getattr__(self, attr):
-        """Get attribute.
-
-        Args:
-            attr (str): Attribute name
-
-        Returns:
-            obj: attribute
-        """
-        if self._module is None:
-            self._module = importlib.import_module(self._module_name)
-
-        return getattr(self._module, attr)
+    if name in class_module_map:
+        module = importlib.import_module(f"{directory}.{class_module_map[name]}")
+        return getattr(module, name)
+    raise AttributeError(f"Directory {directory} has no module {name}!")


### PR DESCRIPTION
## Description and Context:<br> What and Why?
<!--
Provide a brief and concise description of your proposed change.
In particular: Why is this change required? What problem does it solve? Is this a breaking change?
-->
This PR introduces a new approach for lazy imports for faster startup of Queens. The idea is to import all models and iterators lazily instead of trying lazy import of packages like tenforflow, torch, etc....
If this approach is approved, I can also add it to the other classes like Schedulers, Distributions, etc...

I tested the following:
 - Autocomplete in IDE still works
 - Import time for the README example reduced from 5.4s to 1.4s
 
The input file workflow is not supported anymore. It could be, but I am not sure if it is worth the effort anymore...


## Related Issues and Pull Requests
<!--
If applicable: how is this pull request related to other open issues or pull requests?
-->
* Closes
* Related to

## Interested Parties
<!--
If there's anyone you think should be looped in on this pull request,
feel free to @mention them here!
-->
@queens-py/maintainers 
