### PR TITLE
docs: specify waiting time is business days only

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,5 +94,5 @@ your source directory. For further information, see our [testing README.md](test
 #### 5. Submit a pull request
 Please use the available pull request template and fill out all sections of the template.
 When you have submitted a pull request and the CI pipeline passes, it will be reviewed.
-Once your pull request is approved, there is a 24h waiting time until the branch is merged into the
+Once your pull request is approved, there is a 24h waiting time (business days only) until the branch is merged into the
 main branch by the QUEENS maintainers. This ensures that the community has a chance to have a final look over the changes.


### PR DESCRIPTION
## Description and Context:<br> What and Why?
<!--
Provide a brief and concise description of your proposed change.
In particular: Why is this change required? What problem does it solve? Is this a breaking change?
-->
This PR updates our CONTRIBUTING.md to specify that the 24-hour waiting time after a PR is approved only includes business days.

## Related Issues and Pull Requests
<!--
If applicable: how is this pull request related to other open issues or pull requests?
-->
* Closes
* Related to

## Interested Parties
<!--
If there's anyone you think should be looped in on this pull request,
feel free to @mention them here!
-->
