### PR TITLE
build: install fourcipp from pypi

### DIFF
--- a/src/queens_interfaces/fourc/fourc_requirements.txt
+++ b/src/queens_interfaces/fourc/fourc_requirements.txt
@@ -1,1 +1,1 @@
-fourcipp@git+https://github.com/4C-multiphysics/fourcipp.git@main
+fourcipp


### PR DESCRIPTION
## Description and Context:<br> What and Why?
Fourcipp is now available directly from pypi, so no need to install it via git.

## Related Issues and Pull Requests
* Closes
* Related to

## Interested Parties
