### PR TITLE
Allow reuse of Dask schedulers

### DIFF
--- a/src/queens/schedulers/cluster.py
+++ b/src/queens/schedulers/cluster.py
@@ -111,6 +111,14 @@ class Cluster(Dask):
         # sync remote source code with local state
         self.remote_connection.sync_remote_repository()
 
+        self.workload_manager = workload_manager
+        self.walltime = walltime
+        self.min_jobs = min_jobs
+        self.num_nodes = num_nodes
+        self.queue = queue
+        self.cluster_internal_address = cluster_internal_address
+        self.allowed_failures = allowed_failures
+
         # get the path of the experiment directory on remote host
         experiment_dir = self.remote_connection.run_function(experiment_directory, experiment_name)
         _logger.debug(
@@ -120,18 +128,36 @@ class Cluster(Dask):
             experiment_dir,
         )
 
+        super().__init__(
+            experiment_name=experiment_name,
+            experiment_dir=experiment_dir,
+            num_jobs=num_jobs,
+            num_procs=num_procs,
+            restart_workers=restart_workers,
+            verbose=verbose,
+        )
+
+    def _start_cluster_and_connect_client(self):
+        """Start a Dask cluster and a client that connects to it.
+
+        Returns:
+               client (Client): Dask client that is connected to and submits computations to a
+                                Dask cluster.
+        """
         # collect all settings for the dask cluster
-        dask_cluster_options = get_option(VALID_WORKLOAD_MANAGERS, workload_manager)
-        job_extra_directives = dask_cluster_options["job_extra_directives"](num_nodes, num_procs)
+        dask_cluster_options = get_option(VALID_WORKLOAD_MANAGERS, self.workload_manager)
+        job_extra_directives = dask_cluster_options["job_extra_directives"](
+            self.num_nodes, self.num_procs
+        )
         job_directives_skip = dask_cluster_options["job_directives_skip"]
-        if queue is None:
+        if self.queue is None:
             job_directives_skip.append("#SBATCH -p")
 
-        hours, minutes, seconds = map(int, walltime.split(":"))
+        hours, minutes, seconds = map(int, self.walltime.split(":"))
         walltime_delta = timedelta(hours=hours, minutes=minutes, seconds=seconds)
 
         # Increase jobqueue walltime by 5 minutes to kill dask workers in time
-        walltime = timedelta_to_str(walltime_delta + timedelta(minutes=5))
+        increased_walltime = timedelta_to_str(walltime_delta + timedelta(minutes=5))
 
         # dask worker lifetime = walltime - 3m +/- 2m
         worker_lifetime = str(int((walltime_delta + timedelta(minutes=2)).total_seconds())) + "s"
@@ -142,38 +168,38 @@ class Cluster(Dask):
         scheduler_options = {
             "port": remote_port,
             "dashboard_address": remote_port_dashboard,
-            "allowed_failures": allowed_failures,
+            "allowed_failures": self.allowed_failures,
         }
-        if cluster_internal_address:
-            scheduler_options["contact_address"] = f"{cluster_internal_address}:{remote_port}"
+        if self.cluster_internal_address is not None:
+            scheduler_options["contact_address"] = f"{self.cluster_internal_address}:{remote_port}"
         dask_cluster_kwargs = {
-            "job_name": experiment_name,
-            "queue": queue,
+            "job_name": self.experiment_name,
+            "queue": self.queue,
             "memory": "10TB",
             "scheduler_options": scheduler_options,
-            "walltime": walltime,
-            "log_directory": str(experiment_dir),
+            "walltime": increased_walltime,
+            "log_directory": str(self.experiment_dir),
             "job_directives_skip": job_directives_skip,
             "job_extra_directives": [job_extra_directives],
             "worker_extra_args": ["--lifetime", worker_lifetime, "--lifetime-stagger", "2m"],
             # keep this hardcoded to 1, the number of threads for the mpi run is handled by
-            # job_extra_directives. Note that the number of workers is not the number of parallel
-            # simulations!
+            # job_extra_directives. Note that the number of workers is not the number of
+            # parallel simulations!
             "cores": 1,
             "processes": 1,
             "n_workers": 1,
         }
         dask_cluster_adapt_kwargs = {
-            "minimum_jobs": min_jobs,
-            "maximum_jobs": num_jobs,
+            "minimum_jobs": self.min_jobs,
+            "maximum_jobs": self.num_jobs,
         }
 
         # actually start the dask cluster on remote host
         stdout, stderr = self.remote_connection.start_cluster(
-            workload_manager,
+            self.workload_manager,
             dask_cluster_kwargs,
             dask_cluster_adapt_kwargs,
-            experiment_dir,
+            self.experiment_dir,
         )
         _logger.debug(stdout)
         _logger.debug(stderr)
@@ -198,16 +224,7 @@ class Cluster(Dask):
             "http://localhost:%i/status",
             local_port_dashboard,
         )
-
-        super().__init__(
-            experiment_name=experiment_name,
-            experiment_dir=experiment_dir,
-            num_jobs=num_jobs,
-            num_procs=num_procs,
-            client=client,
-            restart_workers=restart_workers,
-            verbose=verbose,
-        )
+        return client
 
     def restart_worker(self, worker):
         """Restart a worker.

--- a/src/queens/schedulers/local.py
+++ b/src/queens/schedulers/local.py
@@ -44,25 +44,34 @@ class Local(Dask):
         """
         experiment_dir = experiment_directory(experiment_name=experiment_name)
 
-        cluster = LocalCluster(
-            n_workers=num_jobs,
-            processes=True,
-            threads_per_worker=num_procs,
-            silence_logs=False,
-        )
-        client = Client(cluster)
-        _logger.info(
-            "To view the Dask dashboard open this link in your browser: %s", client.dashboard_link
-        )
         super().__init__(
             experiment_name=experiment_name,
             experiment_dir=experiment_dir,
             num_jobs=num_jobs,
             num_procs=num_procs,
-            client=client,
             restart_workers=restart_workers,
             verbose=verbose,
         )
+
+    def _start_cluster_and_connect_client(self):
+        """Start a Dask cluster and a client that connects to it.
+
+        Returns:
+               client (Client): Dask client that is connected to and submits computations to a
+                                Dask cluster.
+        """
+        cluster = LocalCluster(
+            n_workers=self.num_jobs,
+            processes=True,
+            threads_per_worker=self.num_procs,
+            silence_logs=False,
+        )
+        client = Client(cluster)
+        _logger.info(
+            "To view the Dask dashboard open this link in your browser: %s",
+            client.dashboard_link,
+        )
+        return client
 
     def restart_worker(self, worker):
         """Restart a worker.


### PR DESCRIPTION
## Description and Context:<br> What and Why?
<!--
Provide a brief and concise description of your proposed change.
In particular: Why is this change required? What problem does it solve? Is this a breaking change?
-->
Previously, the Dask client was always shut down when leaving the global settings context. Because cluster creation and client connection happened only in the scheduler’s __init__, there was no way to restart them once shut down.

This change introduces a method to restart a cluster and connect a new client if the cluster was already shut down. As a result, the same scheduler object can be reused for a second experiment in the same Python process, allowing models to be reused across different global setting contexts.

### Example:
This would not have worked but would now. Note that the exact same model, i.e., the exact same scheduler object is reused.
```python
import numpy as np
import time

from queens.distributions import Uniform
from queens.drivers import Function
from queens.global_settings import GlobalSettings
from queens.iterators import Optimization, Grid
from queens.main import run_iterator
from queens.models import Simulation
from queens.parameters import Parameters
from queens.schedulers import Local

output_dir = "./"
global_settings = GlobalSettings(experiment_name="optimization", output_dir=output_dir)

x1 = Uniform(lower_bound=-2.0, upper_bound=2.0)
x2 = Uniform(lower_bound=-2.0, upper_bound=2.0)
parameters = Parameters(x1=x1, x2=x2)

# Setup iterator
driver = Function(parameters=parameters, function="rosenbrock60")
scheduler = Local(
    experiment_name=global_settings.experiment_name,
    num_jobs=parameters.num_parameters + 1,
    num_procs=1,
    restart_workers=False,
    verbose=True,
)
model = Simulation(scheduler=scheduler, driver=driver)

# scheduler = Pool(experiment_name=global_settings.experiment_name)
iterator_1 = Optimization(
    algorithm="L-BFGS-B",
    initial_guess=[-3.0, -4.0],
    result_description={"write_results": True},
    bounds=[float("-inf"), float("inf")],
    max_feval=1,  # currently this does not do anything -> bug! similarly maxiter is not exposed!
    model=model,
    parameters=parameters,
    global_settings=global_settings,
    objective_and_jacobian=True,  # allows parallel evaluation of function evaluation and FD gradient
)

# The method of the analysis is defined by the iterator type:
grid_design = {
        "x1": {"num_grid_points": 10, "axis_type": "lin", "data_type": "FLOAT"},
        "x2": {"num_grid_points": 10, "axis_type": "lin", "data_type": "FLOAT"},
    }


global_settings_2 = GlobalSettings(experiment_name="Grid", output_dir=output_dir)
iterator_2 = Grid(
    grid_design=grid_design,
    model=model,
    parameters=parameters,
    global_settings=global_settings_2,
    result_description={"write_results": True},
)

if __name__ == "__main__":
    with global_settings:
        # Actual analysis
        run_iterator(iterator_1, global_settings=global_settings)
    
    with global_settings_2:
        # Actual analysis
        run_iterator(iterator_2, global_settings=global_settings_2)
```


## Related Issues and Pull Requests
<!--
If applicable: how is this pull request related to other open issues or pull requests?
-->
* Closes
* Related to

## Interested Parties
<!--
If there's anyone you think should be looped in on this pull request,
feel free to @mention them here!
-->
