### PR TITLE
Set threads per worker of LocalCluster to 1

### DIFF
--- a/src/queens/schedulers/local.py
+++ b/src/queens/schedulers/local.py
@@ -57,7 +57,8 @@ class Local(Dask):
             experiment_name=experiment_name,
             experiment_dir=experiment_dir,
             num_jobs=num_jobs,
-            num_procs=num_procs,
+            num_procs=1,  # keep this hardcoded to 1,
+            # the number of threads for the mpi run is handled by the driver.
             restart_workers=restart_workers,
             verbose=verbose,
         )


### PR DESCRIPTION
## Description and Context:<br> What and Why?
<!--
Provide a brief and concise description of your proposed change.
In particular: Why is this change required? What problem does it solve? Is this a breaking change?
-->

As discussed in #210, the Dask LocalCluster should only start one thread per worker, as the number of threads per worker is handled by the driver, not the Dask cluster itself. This aligns with the setup of the queens Cluster scheduler.

## Related Issues and Pull Requests
<!--
If applicable: how is this pull request related to other open issues or pull requests?
-->
* Closes #210 

## Interested Parties
@gilrrei 
