### PR TITLE
Change the `num_proc` flag in mpi commands

### DIFF
--- a/src/queens/drivers/mpi.py
+++ b/src/queens/drivers/mpi.py
@@ -18,7 +18,7 @@ from queens.drivers.jobscript import Jobscript
 from queens.utils.logger_settings import log_init_args
 
 _JOBSCRIPT_TEMPLATE = (
-    "{{ mpi_cmd }} -np {{ num_procs }} {{ executable }} {{ input_file }} {{ output_file }}"
+    "{{ mpi_cmd }} -n {{ num_procs }} {{ executable }} {{ input_file }} {{ output_file }}"
 )
 
 

--- a/src/queens_interfaces/fourc/driver.py
+++ b/src/queens_interfaces/fourc/driver.py
@@ -18,10 +18,10 @@ from queens.drivers.jobscript import Jobscript
 from queens.utils.logger_settings import log_init_args
 
 _JOBSCRIPT_TEMPLATE = """
-{{ mpi_cmd }} -np {{ num_procs }} {{ executable }} {{ input_file }} {{ output_file }}
+{{ mpi_cmd }} -n {{ num_procs }} {{ executable }} {{ input_file }} {{ output_file }}
 if [ ! -z "{{ post_processor|default("") }}" ]
 then
-  {{ mpi_cmd }} -np {{ num_procs }} {{ post_processor }} --file={{ output_file }} {{ post_options }}
+  {{ mpi_cmd }} -n {{ num_procs }} {{ post_processor }} --file={{ output_file }} {{ post_options }}
 fi
 """
 


### PR DESCRIPTION
## Description and Context:<br> What and Why?
<!--
Provide a brief and concise description of your proposed change.
In particular, Why is this change required? What problem does it solve? Is this a breaking change?
-->

Using `mpriun -n` instead of `-np` is a more general syntax valid for all MPI implementations.
In particular, `mpirun -n` works for OpenMPI and Intel MPI. Another advantage is that this enables using `srun` as the `mpi_cmd`, which is helpful when executing queens through a SLURM jobfile.

## Related Issues and Pull Requests
<!--
If applicable: how is this pull request related to other open issues or pull requests?
-->

## Interested Parties
<!--
If there's anyone you think should be looped in on this pull request,
feel free to @mention them here!
-->
Please insist if you think there are any downsides of `mpirun -n`, I'm actually not an MPI expert at all!
