### PR TITLE
docs: add PR procedure note to the MR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,3 +16,5 @@ If applicable: how is this pull request related to other open issues or pull req
 If there's anyone you think should be looped in on this pull request,
 feel free to @mention them here!
 -->
+
+> Note: More information on the merge request procedure in QUEENS can be found in the [*Submit a pull request*](../CONTRIBUTING.md#5-submit-a-pull-request) section in the [CONTRIBUTING.md](../CONTRIBUTING.md) file.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,3 +96,6 @@ Please use the available pull request template and fill out all sections of the 
 When you have submitted a pull request and the CI pipeline passes, it will be reviewed.
 Once your pull request is approved, there is a 24h waiting time (business days only) until the branch is merged into the
 main branch by the QUEENS maintainers. This ensures that the community has a chance to have a final look over the changes.
+This rule can be circumvented if and only if:
+- All the active maintainers approve the pull request.
+- The pull request is labeled as a quickfix by one of the maintainers and approved. Examples for this are one-liners, typos or urgent fixes that are time-critical.


### PR DESCRIPTION
## Description and Context:<br> What and Why?
This PR adds:
- the 24h waiting exceptions to the `CONTRIBUTING.md`
- a note in the PR templates to the section related to PRs in the  `CONTRIBUTING.md`

## Related Issues and Pull Requests
* Closes
* Related to

## Interested Parties