### PR TITLE
Quickfix: TypeError in cluster tests due to missing positional argument

### DIFF
--- a/tests/integration_tests/cluster/test_fourc_mc_cluster.py
+++ b/tests/integration_tests/cluster/test_fourc_mc_cluster.py
@@ -81,12 +81,18 @@ class TestDaskCluster:
         Note that we also rely on this local mock here!
         """
 
-        def patch_experiments_directory(experiment_name):
+        def patch_experiments_directory(experiment_name, experiment_base_directory=None):
             """Base directory for all experiments on the computing machine."""
-            experiments_dir = (
-                Path(queens_base_directory_on_cluster.replace("$HOME", str(Path.home())))
-                / experiment_name
-            )
+            if experiment_base_directory is None:
+                experiment_base_directory = Path(
+                    queens_base_directory_on_cluster.replace("$HOME", str(Path.home()))
+                )
+            else:
+                raise ValueError(
+                    "This mock function does not support specifying 'experiment_base_directory'. "
+                    "It must be called with 'experiment_base_directory=None'."
+                )
+            experiments_dir = experiment_base_directory / experiment_name
             Path.mkdir(experiments_dir, parents=True, exist_ok=True)
             return experiments_dir
 


### PR DESCRIPTION
## Description and Context:<br> What and Why?
<!--
Provide a brief and concise description of your proposed change.
In particular: Why is this change required? What problem does it solve? Is this a breaking change?
-->
With PR #200, the signature of the experiment_directory utility function was updated.
This change needs to be reflected in the corresponding mock function used for cluster tests.

Without updating the mock, a TypeError is raised during test execution, causing the affected cluster tests to fail.

Thus, this PR suggests a mock implementation of experiment_directory that matches the new function signature.

## Related Issues and Pull Requests
<!--
If applicable: how is this pull request related to other open issues or pull requests?
-->
* Closes
* Related to #200

## Interested Parties
<!--
If there's anyone you think should be looped in on this pull request,
feel free to @mention them here!
-->
@gilrrei 