### PR TITLE
fix: Restore PR211

### DIFF
--- a/src/queens/schedulers/local.py
+++ b/src/queens/schedulers/local.py
@@ -53,12 +53,12 @@ class Local(Dask):
             experiment_name=experiment_name, experiment_base_directory=experiment_base_dir
         )
 
+        # pylint: disable=duplicate-code
         super().__init__(
             experiment_name=experiment_name,
             experiment_dir=experiment_dir,
             num_jobs=num_jobs,
-            num_procs=1,  # keep this hardcoded to 1,
-            # the number of threads for the mpi run is handled by the driver.
+            num_procs=num_procs,
             restart_workers=restart_workers,
             verbose=verbose,
         )
@@ -73,7 +73,8 @@ class Local(Dask):
         cluster = LocalCluster(
             n_workers=self.num_jobs,
             processes=True,
-            threads_per_worker=self.num_procs,
+            threads_per_worker=1,  # keep this hardcoded to 1,
+            # the number of threads for the mpi run is handled by the driver.
             silence_logs=False,
         )
         client = Client(cluster)


### PR DESCRIPTION
## Description and Context:<br> What and Why?
<!--
Provide a brief and concise description of your proposed change.
In particular: Why is this change required? What problem does it solve? Is this a breaking change?
-->

This went wrong when merging #211. 
In the current configuration, the `num_procs` of the `Local(Dask)` cluster is hardcoded to 1, **not** the `num_procs` of the `dask.distributed.LocalCluster`, as it should be.

## Related Issues and Pull Requests
<!--
If applicable: how is this pull request related to other open issues or pull requests?
-->
* Related to #211 and #210

## Interested Parties
@gilrrei & @sbrandstaeter (since you reviewed that last time)
<!--
If there's anyone you think should be looped in on this pull request,
feel free to @mention them here!
-->

> Note: More information on the merge request procedure in QUEENS can be found in the [*Submit a pull request*](../CONTRIBUTING.md#5-submit-a-pull-request) section in the [CONTRIBUTING.md](../CONTRIBUTING.md) file.