### PR TITLE
fix: Enable Pylance for log_init_args decorator

### DIFF
--- a/src/queens/utils/logger_settings.py
+++ b/src/queens/utils/logger_settings.py
@@ -19,7 +19,7 @@ import inspect
 import logging
 import sys
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, ParamSpec
 
 from queens.utils.printing import get_str_table
 
@@ -242,7 +242,10 @@ def reset_logging() -> None:
                 logger.removeHandler(handler)
 
 
-def log_init_args(method: Callable) -> Callable:
+P = ParamSpec("P")
+
+
+def log_init_args(method: Callable[P, None]) -> Callable[P, None]:
     """Log arguments of __init__ method.
 
     Args:
@@ -252,7 +255,7 @@ def log_init_args(method: Callable) -> Callable:
     """
 
     @functools.wraps(method)
-    def wrapper(*args: Any, **kwargs: Any) -> None:
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> None:
         signature = inspect.signature(method)
         default_kwargs = {
             k: v.default


### PR DESCRIPTION
## Description and Context:<br> What and Why?
<!--
Provide a brief and concise description of your proposed change.
In particular: Why is this change required? What problem does it solve? Is this a breaking change?
-->

This modifies the `@log_init_args` decorator slightly. The main motivation is to make the arguments visible for pylance, such that you get autocomplete and nice hovering. I believe that this could especially useful when it comes to typehinting as well.

Before:
<img width="312" height="318" alt="image" src="https://github.com/user-attachments/assets/8c4205dc-db03-4724-ba75-4db7dd9b0f83" />


Afterwards: 
<img width="312" height="318" alt="image" src="https://github.com/user-attachments/assets/eb0bb35b-4eb8-4f68-83c0-6a8e4f8e0338" />


## Related Issues and Pull Requests
<!--
If applicable: how is this pull request related to other open issues or pull requests?
-->
* Closes
* Related to

## Interested Parties
<!--
If there's anyone you think should be looped in on this pull request,
feel free to @mention them here!
-->

> Note: More information on the merge request procedure in QUEENS can be found in the [*Submit a pull request*](../CONTRIBUTING.md#5-submit-a-pull-request) section in the [CONTRIBUTING.md](../CONTRIBUTING.md) file.