### PR TITLE
quickfix: use all suffixes for input files

### DIFF
--- a/src/queens/drivers/jobscript.py
+++ b/src/queens/drivers/jobscript.py
@@ -268,7 +268,7 @@ class Jobscript(Driver):
 
         input_files = {}
         for input_template_name, input_template_path in self.input_templates.items():
-            input_file_str = input_template_name + input_template_path.suffix
+            input_file_str = input_template_name + "".join(input_template_path.suffixes)
             input_files[input_template_name] = job_dir / input_file_str
 
         return job_dir, output_dir, output_file, input_files, log_file


### PR DESCRIPTION
## Description and Context:<br> What and Why?
<!--
Provide a brief and concise description of your proposed change.
In particular: Why is this change required? What problem does it solve? Is this a breaking change?
-->
Currently, only the last suffix is used for input files. So in the case of a `template.4C.yaml` input file, only the `.yaml` suffix and not `.4C.yaml` is used. With this PR, all suffixes are used for the input files.

## Related Issues and Pull Requests
<!--
If applicable: how is this pull request related to other open issues or pull requests?
-->
* Closes
* Related to

## Interested Parties
<!--
If there's anyone you think should be looped in on this pull request,
feel free to @mention them here!
-->
@dragos-ana 

> Note: More information on the merge request procedure in QUEENS can be found in the [*Submit a pull request*](../CONTRIBUTING.md#5-submit-a-pull-request) section in the [CONTRIBUTING.md](../CONTRIBUTING.md) file.