### PR TITLE
feat: add flag & user prompt to overwrite existing experiment directory

### DIFF
--- a/src/queens/schedulers/_dask.py
+++ b/src/queens/schedulers/_dask.py
@@ -34,9 +34,9 @@ class Dask(Scheduler):
     """Abstract base class for schedulers in QUEENS.
 
     Attributes:
-        num_procs (int): number of processors per job
+        num_procs (int): Number of processors per job
         client (Client): Dask client that connects to and submits computation to a Dask cluster
-        restart_workers (bool): If true, restart workers after each finished job
+        restart_workers (bool): If True, restart workers after each finished job
     """
 
     def __init__(
@@ -51,11 +51,11 @@ class Dask(Scheduler):
         """Initialize scheduler.
 
         Args:
-            experiment_name (str): name of QUEENS experiment.
+            experiment_name (str): Name of QUEENS experiment.
             experiment_dir (Path): Path to QUEENS experiment directory.
             num_jobs (int): Maximum number of parallel jobs
-            num_procs (int): number of processors per job
-            restart_workers (bool): If true, restart workers after each finished job
+            num_procs (int): Number of processors per job
+            restart_workers (bool): If True, restart workers after each finished job
             verbose (bool, opt): Verbosity of evaluations. Defaults to True.
         """
         super().__init__(
@@ -75,8 +75,8 @@ class Dask(Scheduler):
         """Start a Dask cluster and a client that connects to it.
 
         Returns:
-               client (Client): Dask client that is connected to and submits computations to a
-                                Dask cluster.
+            client (Client): Dask client that is connected to and submits computations to a Dask
+                cluster.
         """
 
     def start_cluster_and_connect_client(self):
@@ -92,8 +92,8 @@ class Dask(Scheduler):
         The Dask client and cluster will be shut down when leaving the GlobalSettings context.
 
         Args:
-            client (Client): Dask client that is connected to and submits computations to a
-                             Dask cluster.
+            client (Client): Dask client that is connected to and submits computations to a Dask
+                cluster.
         """
         global SHUTDOWN_CLIENTS  # pylint: disable=global-variable-not-assigned
         SHUTDOWN_CLIENTS.append(client.shutdown)

--- a/src/queens/schedulers/cluster.py
+++ b/src/queens/schedulers/cluster.py
@@ -93,23 +93,23 @@ class Cluster(Dask):
         The total number of cores per job is given by num_procs*num_nodes.
 
         Args:
-            experiment_name (str): name of the current experiment
+            experiment_name (str): Name of the current experiment
             workload_manager (str): Workload manager ("pbs" or "slurm")
             walltime (str): Walltime for each worker job. Format (hh:mm:ss)
-            remote_connection (RemoteConnection): ssh connection to the remote host
+            remote_connection (RemoteConnection): SSH connection to the remote host
             num_jobs (int, opt): Maximum number of parallel jobs
             min_jobs (int, opt): Minimum number of active workers for the cluster
             num_procs (int, opt): Number of processors per job per node
             num_nodes (int, opt): Number of cluster nodes per job
             queue (str, opt): Destination queue for each worker job
             cluster_internal_address (str, opt): Internal address of cluster
-            restart_workers (bool): If true, restart workers after each finished job. For larger
-                                    jobs (>1min) this should be set to true in most cases.
+            restart_workers (bool): If True, restart workers after each finished job. For larger
+                jobs (>1min) this should be set to True in most cases.
             allowed_failures (int): Number of allowed failures for a task before an error is raised
             verbose (bool, opt): Verbosity of evaluations. Defaults to True.
             experiment_base_dir (str, Path): Base directory for the simulation outputs
-            overwrite_existing_experiment (bool): If true, overwrite experiment directory if it
-                exists already. If false, prompt user for confirmation before overwriting.
+            overwrite_existing_experiment (bool): If True, overwrite experiment directory if it
+                exists already. If False, prompt user for confirmation before overwriting.
         """
         self.remote_connection = remote_connection
         self.remote_connection.open()
@@ -160,23 +160,39 @@ class Cluster(Dask):
         Returns:
             experiment_dir (Path): Path to experiment directory on remote host.
         """
-        experiment_dir = self.remote_connection.run_function(
+        experiment_dir, experiment_dir_exists = self.remote_connection.run_function(
             experiment_directory, experiment_name, experiment_base_dir
         )
-        if not overwrite_existing_experiment:
-            experiment_dir_exists = self.remote_connection.run_function(experiment_dir.exists)
-            if experiment_dir_exists:
-                self.get_user_confirmation_to_overwrite(experiment_dir)
+        if not overwrite_existing_experiment and experiment_dir_exists:
+            self.get_user_confirmation_to_overwrite(experiment_dir)
         self.remote_connection.run_function(create_directory, experiment_dir)
 
         return experiment_dir
+
+    def local_experiment_dir(
+        self, experiment_name, experiment_base_dir, overwrite_existing_experiment
+    ):
+        """Get the local experiment directory.
+
+        Args:
+            experiment_name (str): name of the current experiment
+            experiment_base_dir (str, Path): Base directory for the simulation outputs
+            overwrite_existing_experiment (bool): If true, continue and overwrite experiment
+                directory. If false, prompt user for confirmation before continuing and overwriting.
+
+        Returns:
+            experiment_dir (Path): Path to local experiment directory.
+        """
+        raise NotImplementedError(
+            "The Cluster scheduler should not use the local but the remote experiment directory."
+        )
 
     def _start_cluster_and_connect_client(self):
         """Start a Dask cluster and a client that connects to it.
 
         Returns:
-               client (Client): Dask client that is connected to and submits computations to a
-                                Dask cluster.
+            client (Client): Dask client that is connected to and submits computations to a Dask
+                cluster.
         """
         # collect all settings for the dask cluster
         dask_cluster_options = get_option(VALID_WORKLOAD_MANAGERS, self.workload_manager)
@@ -275,8 +291,8 @@ class Cluster(Dask):
         """Copy file to experiment directory.
 
         Args:
-            paths (Path, list): paths to files or directories that should be copied to experiment
-                                directory
+            paths (Path, list): Paths to files or directories that should be copied to experiment
+                directory
         """
         destination = f"{self.experiment_dir}/"
         self.remote_connection.copy_to_remote(paths, destination)

--- a/src/queens/schedulers/local.py
+++ b/src/queens/schedulers/local.py
@@ -41,15 +41,15 @@ class Local(Dask):
         """Initialize local scheduler.
 
         Args:
-            experiment_name (str): name of the current experiment
+            experiment_name (str): Name of the current experiment
             num_jobs (int, opt): Maximum number of parallel jobs
-            num_procs (int, opt): number of processors per job
-            restart_workers (bool): If true, restart workers after each finished job. Try setting it
-                                    to true in case you are experiencing memory-leakage warnings.
+            num_procs (int, opt): Number of processors per job
+            restart_workers (bool): If True, restart workers after each finished job. Try setting it
+                to True in case you are experiencing memory-leakage warnings.
             verbose (bool, opt): Verbosity of evaluations. Defaults to True.
             experiment_base_dir (str, Path): Base directory for the simulation outputs
-            overwrite_existing_experiment (bool): If true, overwrite experiment directory if it
-                exists already. If false, prompt user for confirmation before overwriting.
+            overwrite_existing_experiment (bool): If True, overwrite experiment directory if it
+                exists already. If False, prompt user for confirmation before overwriting.
         """
         # pylint: disable=duplicate-code
         experiment_dir = self.local_experiment_dir(
@@ -68,8 +68,8 @@ class Local(Dask):
         """Start a Dask cluster and a client that connects to it.
 
         Returns:
-               client (Client): Dask client that is connected to and submits computations to a
-                                Dask cluster.
+            client (Client): Dask client that is connected to and submits computations to a Dask
+                cluster.
         """
         cluster = LocalCluster(
             n_workers=self.num_jobs,

--- a/src/queens/schedulers/pool.py
+++ b/src/queens/schedulers/pool.py
@@ -46,13 +46,14 @@ class Pool(Scheduler):
         """Initialize Pool.
 
         Args:
-            experiment_name (str): name of the current experiment
+            experiment_name (str): Name of the current experiment
             num_jobs (int, opt): Maximum number of parallel jobs
             verbose (bool, opt): Verbosity of evaluations. Defaults to True.
             experiment_base_dir (str, Path): Base directory for the simulation outputs
-            overwrite_existing_experiment (bool): If true, overwrite experiment directory if it
-                exists already. If false, prompt user for confirmation before overwriting.
+            overwrite_existing_experiment (bool): If True, overwrite experiment directory if it
+                exists already. If False, prompt user for confirmation before overwriting.
         """
+        # pylint: disable=duplicate-code
         experiment_dir = self.local_experiment_dir(
             experiment_name, experiment_base_dir, overwrite_existing_experiment
         )

--- a/src/queens/utils/config_directories.py
+++ b/src/queens/utils/config_directories.py
@@ -51,7 +51,7 @@ def base_directory() -> Path:
 
 def experiment_directory(
     experiment_name: str, experiment_base_directory: str | Path | None = None
-) -> Path:
+) -> tuple[Path, bool]:
     """Directory for data of a specific experiment on the computing machine.
 
     If no experiment_base_directory is provided, base_directory() is used as default.
@@ -62,6 +62,7 @@ def experiment_directory(
 
     Returns:
         Experiment directory
+        Whether experiment directory already exists
     """
     if experiment_base_directory is None:
         experiment_base_directory = base_directory()
@@ -69,7 +70,7 @@ def experiment_directory(
         experiment_base_directory = Path(experiment_base_directory)
 
     experiment_dir = experiment_base_directory / experiment_name
-    return experiment_dir
+    return experiment_dir, experiment_dir.exists()
 
 
 def create_directory(dir_path: str | Path) -> None:

--- a/tests/integration_tests/fourc/test_fourc_mc.py
+++ b/tests/integration_tests/fourc/test_fourc_mc.py
@@ -87,7 +87,7 @@ def test_fourc_mc(
             results["raw_output_data"]["result"], fourc_example_expected_output, decimal=6
         )
     except Exception as error:
-        experiment_dir = experiment_directory(global_settings.experiment_name)
+        experiment_dir, _ = experiment_directory(global_settings.experiment_name)
         job_dir = experiment_dir / "0"
         _logger.info(list(job_dir.iterdir()))
         output_dir = job_dir / "output"

--- a/tests/integration_tests/fourc/test_fourc_mc_random_material_field.py
+++ b/tests/integration_tests/fourc/test_fourc_mc_random_material_field.py
@@ -114,7 +114,7 @@ def test_write_random_elementwise_material(
         # Check if we got the expected results
         np.testing.assert_array_almost_equal(results["mean"], expected_mean, decimal=8)
     except Exception as error:
-        experiment_dir = experiment_directory(global_settings.experiment_name)
+        experiment_dir, _ = experiment_directory(global_settings.experiment_name)
         job_dir = experiment_dir / "0"
         _logger.info(list(job_dir.iterdir()))
         output_dir = job_dir / "output"

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -30,12 +30,6 @@ def fixture_dummy_simulation_model():
     return model
 
 
-@pytest.fixture(name="experiment_name")
-def fixture_experiment_name():
-    """Fixture for the experiment_name."""
-    return "test_experiment"
-
-
 @pytest.fixture(name="files_to_copy")
 def fixture_files_to_copy():
     """Files to copy."""

--- a/tests/unit_tests/drivers/test_jobscript.py
+++ b/tests/unit_tests/drivers/test_jobscript.py
@@ -136,7 +136,7 @@ def fixture_injected_input_files(tmp_path, job_id):
 
 
 @pytest.fixture(name="job_options")
-def fixture_job_options(tmp_path, job_id, experiment_name, injected_input_files):
+def fixture_job_options(tmp_path, job_id, test_name, injected_input_files):
     """Job options to be injected."""
     num_procs = 4
     experiment_dir = tmp_path
@@ -148,7 +148,7 @@ def fixture_job_options(tmp_path, job_id, experiment_name, injected_input_files)
         job_id=job_id,
         num_procs=num_procs,
         experiment_dir=experiment_dir,
-        experiment_name=experiment_name,
+        experiment_name=test_name,
         input_files=injected_input_files,
     )
 

--- a/tests/unit_tests/tutorials/test_tutorials.py
+++ b/tests/unit_tests/tutorials/test_tutorials.py
@@ -25,12 +25,25 @@ from testbook import testbook
         "tutorials/2-grid-iterator-rosenbrock.ipynb",
     ],
 )
-def test_notebooks(notebook_path):
+def test_notebooks(tmp_path, notebook_path):
     """Parameterized test case for multiple Jupyter notebooks.
 
     The notebook is run and it is checked that it runs through without
     any errors/assertions.
     """
     with testbook(notebook_path) as tb:
+        # Patch base_directory to avoid writing test data to user's home dir.
+        # Note that tb.patch converts the mocked Path to a string, so we have to use tb.inject.
+        tb.inject(
+            f"""
+            from unittest.mock import MagicMock
+            from pathlib import Path
+            import queens.utils.config_directories
+            mock_base_dir = Path('{tmp_path}')
+            queens.utils.config_directories.base_directory = MagicMock(return_value=mock_base_dir)
+            """,
+            before=0,
+        )
+
         # execute the notebook
         tb.execute()


### PR DESCRIPTION
## Description and Context:<br> What and Why?
<!--
Provide a brief and concise description of your proposed change.
In particular: Why is this change required? What problem does it solve? Is this a breaking change?
-->
As discussed during queens-py/queens-meetings#20, this PR adds a flag to the schedulers to allow overwriting the directory of an already existing experiment with the same name.
If the flag is set to False and the experiment directory already exists, a prompt asks the user to confirm overwriting the experiment by entering "y". If no input is given within 10 seconds or any other input than "y" is given, the QUEENS run is aborted.

This feature will hopefully prevent data loss, especially for new QUEENS users in the future.

The new cluster tests for this feature were tested on gitlab: https://gitlab.lrz.de/queens_community/queens/-/pipelines/2771223

## Related Issues and Pull Requests
<!--
If applicable: how is this pull request related to other open issues or pull requests?
-->
* Closes #10
* Related to

## Interested Parties
<!--
If there's anyone you think should be looped in on this pull request,
feel free to @mention them here!
-->

> Note: More information on the merge request procedure in QUEENS can be found in the [*Submit a pull request*](../CONTRIBUTING.md#5-submit-a-pull-request) section in the [CONTRIBUTING.md](../CONTRIBUTING.md) file.
