### PR TITLE
Add parameters dict to sample conversion

### DIFF
--- a/src/queens/parameters/parameters.py
+++ b/src/queens/parameters/parameters.py
@@ -254,6 +254,18 @@ class Parameters:
             sample_dict[key] = sample[j]
         return sample_dict
 
+    def dict_as_sample(self, sample_dict: dict) -> np.ndarray:
+        """Opposite of `sample_as_dict`: Convert sample_dict to sample array.
+
+        Args:
+            sample_dict: dict containing the sample.
+                The keys must correspond to parameter keys. The order of the keys does not matter.
+
+        Returns:
+            sample: sample array in correct order
+        """
+        return np.array([sample_dict[key] for key in self.parameters_keys])
+
     def expand_random_field_realization(self, truncated_sample: np.ndarray) -> np.ndarray:
         """Expand truncated representation of random fields.
 

--- a/tests/unit_tests/parameters/test_parameters.py
+++ b/tests/unit_tests/parameters/test_parameters.py
@@ -140,6 +140,13 @@ def test_sample_as_dict(parameters_set_1):
     assert sample_dict == {"x1": 0.5, "x2_0": 0.1, "x2_1": 0.6}
 
 
+def test_dict_as_sample(parameters_set_1):
+    """Test *dict_as_sample* method."""
+    sample_dict = {"x2_0": 0.1, "x2_1": 0.6, "x1": 0.5}  # ordering does not matter
+    sample_array = parameters_set_1.dict_as_sample(sample_dict)
+    np.testing.assert_array_equal(sample_array, np.array([0.5, 0.1, 0.6]))
+
+
 def test_to_list(parameters_set_1):
     """Test *to_list* method."""
     parameters_list = parameters_set_1.to_list()


### PR DESCRIPTION
## Description and Context:<br> What and Why?
<!--
Provide a brief and concise description of your proposed change.
In particular: Why is this change required? What problem does it solve? Is this a breaking change?
-->

I think it makes sense to have this, as we already have `sample_as_dict` as well. Sometimes, modifying a dict instead of a raw sample is easier, since you do not need to remember the indices in the sample and do not accidentally edit the sample in the wrong way.

## Related Issues and Pull Requests
<!--
If applicable: how is this pull request related to other open issues or pull requests?
-->
* Closes
* Related to

## Interested Parties
<!--
If there's anyone you think should be looped in on this pull request,
feel free to @mention them here!
-->

> Note: More information on the merge request procedure in QUEENS can be found in the [*Submit a pull request*](../CONTRIBUTING.md#5-submit-a-pull-request) section in the [CONTRIBUTING.md](../CONTRIBUTING.md) file.
