### PR TITLE
Remove the need for driver objects in the schedulers

### DIFF
--- a/src/queens/drivers/_driver.py
+++ b/src/queens/drivers/_driver.py
@@ -51,7 +51,7 @@ class Driver(metaclass=abc.ABCMeta):
         """Abstract method for driver run.
 
         Args:
-            sample (dict): Dict containing sample
+            sample (np.ndarray): Input sample
             job_id (int): Job ID
             num_procs (int): number of processors
             experiment_name (str): name of QUEENS experiment.
@@ -60,3 +60,18 @@ class Driver(metaclass=abc.ABCMeta):
         Returns:
             Result and potentially the gradient
         """
+
+    def __call__(self, sample, job_id, num_procs, experiment_dir, experiment_name):
+        """Abstract method for driver run.
+
+        Args:
+            sample (np.ndarray): Input sample
+            job_id (int): Job ID
+            num_procs (int): number of processors
+            experiment_name (str): name of QUEENS experiment.
+            experiment_dir (Path): Path to QUEENS experiment directory.
+
+        Returns:
+            Result and potentially the gradient
+        """
+        return self.run(sample, job_id, num_procs, experiment_dir, experiment_name)

--- a/src/queens/drivers/function.py
+++ b/src/queens/drivers/function.py
@@ -15,7 +15,6 @@
 """Function Driver."""
 
 import inspect
-import logging
 
 import numpy as np
 
@@ -23,8 +22,6 @@ from example_simulator_functions import example_simulator_function_by_name
 from queens.drivers._driver import Driver
 from queens.utils.imports import get_module_attribute
 from queens.utils.logger_settings import log_init_args
-
-_logger = logging.getLogger(__name__)
 
 
 class Function(Driver):
@@ -116,7 +113,7 @@ class Function(Driver):
         """Run the driver.
 
         Args:
-            sample (dict): Dict containing sample
+            sample (np.ndarray): Input sample
             job_id (int): Job ID
             num_procs (int): number of processors
             experiment_name (str): name of QUEENS experiment.

--- a/src/queens/drivers/jobscript.py
+++ b/src/queens/drivers/jobscript.py
@@ -193,7 +193,7 @@ class Jobscript(Driver):
         """Run the driver.
 
         Args:
-            sample (dict): Dict containing sample.
+            sample (np.array): Input sample.
             job_id (int): Job ID.
             num_procs (int): Number of processors.
             experiment_dir (Path): Path to QUEENS experiment directory.

--- a/src/queens/models/adjoint.py
+++ b/src/queens/models/adjoint.py
@@ -83,6 +83,6 @@ class Adjoint(Simulation):
 
         # evaluate the adjoint model
         gradient = self.scheduler.evaluate(
-            samples, driver=self.gradient_driver, job_ids=last_job_ids
+            samples, function=self.gradient_driver, job_ids=last_job_ids
         )["result"]
         return gradient

--- a/src/queens/models/finite_difference.py
+++ b/src/queens/models/finite_difference.py
@@ -89,7 +89,7 @@ class FiniteDifference(Simulation):
             response (dict): Response of the underlying model at input samples
         """
         if not self.evaluate_and_gradient_bool:
-            self.response = self.scheduler.evaluate(samples, driver=self.driver)
+            self.response = self.scheduler.evaluate(samples, self.driver)
         else:
             self.response = self.evaluate_finite_differences(samples)
         return self.response
@@ -144,7 +144,7 @@ class FiniteDifference(Simulation):
 
         # stack samples and stencil points and evaluate entire batch
         combined_samples = np.vstack((samples, stencil_samples))
-        all_responses = self.scheduler.evaluate(combined_samples, driver=self.driver)[
+        all_responses = self.scheduler.evaluate(combined_samples, function=self.driver)[
             "result"
         ].reshape(combined_samples.shape[0], -1)
 

--- a/src/queens/models/simulation.py
+++ b/src/queens/models/simulation.py
@@ -50,7 +50,7 @@ class Simulation(Model):
         Returns:
             response (dict): Response of the underlying model at input samples
         """
-        self.response = self.scheduler.evaluate(samples, driver=self.driver)
+        self.response = self.scheduler.evaluate(samples, self.driver)
         return self.response
 
     def grad(self, samples, upstream_gradient):

--- a/src/queens/schedulers/_scheduler.py
+++ b/src/queens/schedulers/_scheduler.py
@@ -18,6 +18,9 @@ import abc
 import logging
 import select
 import sys
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Protocol
 
 import numpy as np
 
@@ -25,6 +28,31 @@ from queens.utils.config_directories import create_directory, experiment_directo
 from queens.utils.rsync import rsync
 
 _logger = logging.getLogger(__name__)
+
+
+class SchedulerCallableSignature(Protocol):
+    """Signature for callables which can be used with QUEENS schedulers."""
+
+    def __call__(
+        self,
+        sample: np.ndarray,
+        job_id: int,
+        num_procs: int,
+        experiment_dir: Path,
+        experiment_name: str,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Signature for callables which can be used with QUEENS schedulers.
+
+        Args:
+            sample (np.array): Input ample.
+            job_id (int): Job ID.
+            num_procs (int): Number of processors.
+            experiment_dir (Path): Path to QUEENS experiment directory.
+            experiment_name (str): Name of QUEENS experiment.
+
+        Returns:
+            Result and potentially the gradient.
+        """
 
 
 class Scheduler(metaclass=abc.ABCMeta):
@@ -54,12 +82,14 @@ class Scheduler(metaclass=abc.ABCMeta):
         self.verbose = verbose
 
     @abc.abstractmethod
-    def evaluate(self, samples, driver, job_ids=None):
+    def evaluate(
+        self, samples: Iterable, function: SchedulerCallableSignature, job_ids: Iterable = None
+    ) -> dict:
         """Submit jobs to driver.
 
         Args:
             samples (np.array): Array of samples
-            driver (Driver): Driver object that runs simulation
+            function (Callable): Callable to evaluate in the scheduler
             job_ids (lst, opt): List of job IDs corresponding to samples
 
         Returns:

--- a/tests/unit_tests/models/test_differentiable_adjoint.py
+++ b/tests/unit_tests/models/test_differentiable_adjoint.py
@@ -77,7 +77,7 @@ def test_grad(default_adjoint_model):
     adjoint.write_to_csv = Mock()
     default_adjoint_model.scheduler.next_job_id = 7
     default_adjoint_model.scheduler.experiment_dir = experiment_dir
-    default_adjoint_model.scheduler.evaluate = lambda x, driver, job_ids: {"result": x**2}
+    default_adjoint_model.scheduler.evaluate = lambda x, function, job_ids: {"result": x**2}
 
     np.random.seed(42)
     samples = np.random.random((2, 3))

--- a/tests/unit_tests/models/test_differentiable_fd.py
+++ b/tests/unit_tests/models/test_differentiable_fd.py
@@ -68,7 +68,7 @@ def test_init():
 
 def test_evaluate(default_fd_model):
     """Test the evaluation method."""
-    default_fd_model.scheduler.evaluate = lambda x, driver: {
+    default_fd_model.scheduler.evaluate = lambda x, function: {
         "result": np.sum(x**2, axis=1, keepdims=True)
     }
     samples = np.random.random((3, 2))
@@ -94,7 +94,7 @@ def test_evaluate(default_fd_model):
     np.testing.assert_array_almost_equal(expected_mean, response["result"], decimal=5)
     np.testing.assert_array_almost_equal(expected_grad, response["gradient"], decimal=5)
 
-    default_fd_model.scheduler.evaluate = lambda x, driver: {
+    default_fd_model.scheduler.evaluate = lambda x, function: {
         "result": np.array([np.sum(x**2, axis=1), np.sum(2 * x**2, axis=1)]).T
     }
     samples = np.random.random((3, 4))


### PR DESCRIPTION
## Description and Context:<br> What and Why?
The schedulers currently expect a driver object in the evaluate function, which we only use the `run` method. This PR removes this requirement such that you can use the scheduler to evaluate an arbitrary function in the schedulers, for example, allowing you to train multiple surrogates in parallel, meshing in parallel, whatever pre- or postprocessing you want, for example, extracting different results from existing data simulation data in parallel!

For backwards compatibility, I made the driver callable which keeps the simple interface for the user :)
## Related Issues and Pull Requests
* Related to #234 

## Interested Parties
@rjoussen 

> Note: More information on the merge request procedure in QUEENS can be found in the [*Submit a pull request*](../CONTRIBUTING.md#5-submit-a-pull-request) section in the [CONTRIBUTING.md](../CONTRIBUTING.md) file.
