### PR TITLE
Move result transformation to model

### DIFF
--- a/src/queens/drivers/_driver.py
+++ b/src/queens/drivers/_driver.py
@@ -15,10 +15,9 @@
 """QUEENS driver module base class."""
 
 import abc
-import logging
 from pathlib import Path
 
-_logger = logging.getLogger(__name__)
+import numpy as np
 
 
 class Driver(metaclass=abc.ABCMeta):
@@ -47,7 +46,14 @@ class Driver(metaclass=abc.ABCMeta):
         self.files_to_copy = files_to_copy
 
     @abc.abstractmethod
-    def run(self, sample, job_id, num_procs, experiment_dir, experiment_name):
+    def run(
+        self,
+        sample: np.ndarray,
+        job_id: int,
+        num_procs: int,
+        experiment_dir: Path,
+        experiment_name: str,
+    ) -> dict:
         """Abstract method for driver run.
 
         Args:
@@ -58,7 +64,7 @@ class Driver(metaclass=abc.ABCMeta):
             experiment_dir (Path): Path to QUEENS experiment directory.
 
         Returns:
-            Result and potentially the gradient
+            Results
         """
 
     def __call__(self, sample, job_id, num_procs, experiment_dir, experiment_name):

--- a/src/queens/drivers/function.py
+++ b/src/queens/drivers/function.py
@@ -15,6 +15,7 @@
 """Function Driver."""
 
 import inspect
+from pathlib import Path
 
 import numpy as np
 
@@ -97,7 +98,8 @@ class Function(Driver):
                 if not result.shape:
                     result = np.expand_dims(result, axis=0)
                     gradient = np.expand_dims(gradient, axis=0)
-                return result, gradient
+                return {"result": result, "gradient": gradient}
+
             # here no gradient return
             # take scalars and convert them to numpy floats
             if not isinstance(result_array, np.floating):
@@ -105,11 +107,18 @@ class Function(Driver):
 
             if not result_array.shape:
                 result_array = np.expand_dims(result_array, axis=0)
-            return result_array, None
+            return {"result": result_array}
 
         return reshaped_output_function
 
-    def run(self, sample, job_id, num_procs, experiment_dir, experiment_name):
+    def run(
+        self,
+        sample: np.ndarray,
+        job_id: int,
+        num_procs: int,
+        experiment_dir: Path,
+        experiment_name: str,
+    ) -> dict:
         """Run the driver.
 
         Args:

--- a/src/queens/drivers/jobscript.py
+++ b/src/queens/drivers/jobscript.py
@@ -20,6 +20,8 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
+import numpy as np
+
 from queens.drivers._driver import Driver
 from queens.utils.exceptions import SubprocessError
 from queens.utils.injector import inject, inject_in_template
@@ -189,7 +191,14 @@ class Jobscript(Driver):
 
         return jobscript_template
 
-    def run(self, sample, job_id, num_procs, experiment_dir, experiment_name):
+    def run(
+        self,
+        sample: np.ndarray,
+        job_id: int,
+        num_procs: int,
+        experiment_dir: Path,
+        experiment_name: str,
+    ) -> dict:
         """Run the driver.
 
         Args:
@@ -305,16 +314,17 @@ class Jobscript(Driver):
             result (np.array): Result from the driver run.
             gradient (np.array, None): Gradient from the driver run (potentially None).
         """
-        result = None
+        results = {}
         if self.data_processor:
             result = self.data_processor(output_dir)
+            results["result"] = result
             _logger.debug("Got result: %s", result)
 
-        gradient = None
         if self.gradient_data_processor:
             gradient = self.gradient_data_processor(output_dir)
+            results["gradient"] = gradient
             _logger.debug("Got gradient: %s", gradient)
-        return result, gradient
+        return results
 
     def prepare_input_files(self, sample_dict, experiment_dir, input_files):
         """Prepare and parse data to input files.

--- a/src/queens/models/adjoint.py
+++ b/src/queens/models/adjoint.py
@@ -82,7 +82,7 @@ class Adjoint(Simulation):
             write_to_csv(adjoint_file_path, grad_objective.reshape(1, -1))
 
         # evaluate the adjoint model
-        gradient = self.scheduler.evaluate(
-            samples, function=self.gradient_driver, job_ids=last_job_ids
+        gradient = self.create_result_dict_from_scheduler_output(
+            self.scheduler.evaluate(samples, self.gradient_driver, job_ids=last_job_ids)
         )["result"]
         return gradient

--- a/src/queens/schedulers/_dask.py
+++ b/src/queens/schedulers/_dask.py
@@ -165,14 +165,7 @@ class Dask(Scheduler):
                     )
                 )
 
-        result_dict = {"result": [], "gradient": []}
-        for result in results.values():
-            # We should remove this squeeze! It is only introduced for consistency with old test.
-            result_dict["result"].append(np.atleast_1d(np.array(result[0]).squeeze()))
-            result_dict["gradient"].append(result[1])
-        result_dict["result"] = np.array(result_dict["result"])
-        result_dict["gradient"] = np.array(result_dict["gradient"])
-        return result_dict
+        return list(results.values())
 
     @abc.abstractmethod
     def restart_worker(self, worker):

--- a/src/queens/schedulers/_scheduler.py
+++ b/src/queens/schedulers/_scheduler.py
@@ -40,7 +40,7 @@ class SchedulerCallableSignature(Protocol):
         num_procs: int,
         experiment_dir: Path,
         experiment_name: str,
-    ) -> tuple[np.ndarray, np.ndarray]:
+    ) -> dict:
         """Signature for callables which can be used with QUEENS schedulers.
 
         Args:

--- a/src/queens/schedulers/pool.py
+++ b/src/queens/schedulers/pool.py
@@ -18,7 +18,6 @@ import logging
 from collections.abc import Iterable
 from functools import partial
 
-import numpy as np
 from tqdm import tqdm
 
 from queens.schedulers._scheduler import Scheduler, SchedulerCallableSignature
@@ -95,15 +94,4 @@ class Pool(Scheduler):
         else:
             results = list(map(partial_function, samples, job_ids))
 
-        output = {}
-        # check if gradient is returned --> tuple
-        if isinstance(results[0], tuple):
-            results_iterator, gradient_iterator = zip(*results)
-            results_array = np.array(list(results_iterator))
-            gradients_array = np.array(list(gradient_iterator))
-            output["gradient"] = gradients_array
-        else:
-            results_array = np.array(results)
-
-        output["result"] = results_array
-        return output
+        return results

--- a/tests/unit_tests/models/test_differentiable_fd.py
+++ b/tests/unit_tests/models/test_differentiable_fd.py
@@ -66,43 +66,67 @@ def test_init():
         )
 
 
-def test_evaluate(default_fd_model):
+@pytest.fixture(name="scheduler_response")
+def fixture_scheduler_response():
+    """Scheduler response fixture."""
+
+    def scheduler_response(samples, driver, job_ids=None):  # pylint: disable=unused-argument
+        """Scheduler response."""
+        return [{"result": np.sum(x**2)} for x in samples]
+
+    return scheduler_response
+
+
+def test_evaluate(default_fd_model, scheduler_response):
     """Test the evaluation method."""
-    default_fd_model.scheduler.evaluate = lambda x, function: {
-        "result": np.sum(x**2, axis=1, keepdims=True)
-    }
+    default_fd_model.scheduler.evaluate = scheduler_response
     samples = np.random.random((3, 2))
 
-    expected_mean = np.sum(samples**2, axis=1, keepdims=True)
+    expected_result = np.sum(samples**2, axis=1, keepdims=True)
     expected_grad = 2 * samples[:, np.newaxis, :]
 
     response = default_fd_model.evaluate(samples)
     assert len(response) == 1
-    np.testing.assert_array_equal(response["result"], expected_mean)
+    np.testing.assert_array_equal(response["result"], expected_result)
     assert len(default_fd_model.response) == 1
-    np.testing.assert_array_equal(default_fd_model.response["result"], expected_mean)
+    np.testing.assert_array_equal(default_fd_model.response["result"], expected_result)
 
     Model.evaluate_and_gradient_bool = False
     response = default_fd_model.evaluate(samples)
     assert len(response) == 1
-    np.testing.assert_array_equal(response["result"], expected_mean)
+    np.testing.assert_array_equal(response["result"], expected_result)
     assert len(default_fd_model.response) == 1
-    np.testing.assert_array_equal(default_fd_model.response["result"], expected_mean)
+    np.testing.assert_array_equal(default_fd_model.response["result"], expected_result)
 
     Model.evaluate_and_gradient_bool = True
     response = default_fd_model.evaluate(samples)
-    np.testing.assert_array_almost_equal(expected_mean, response["result"], decimal=5)
+    np.testing.assert_array_almost_equal(expected_result, response["result"], decimal=5)
     np.testing.assert_array_almost_equal(expected_grad, response["gradient"], decimal=5)
+    Model.evaluate_and_gradient_bool = False
 
-    default_fd_model.scheduler.evaluate = lambda x, function: {
-        "result": np.array([np.sum(x**2, axis=1), np.sum(2 * x**2, axis=1)]).T
-    }
+
+@pytest.fixture(name="scheduler_response_2d")
+def fixture_scheduler_response_2d():
+    """Scheduler response with gradient fixture."""
+
+    def scheduler_response(samples, driver, job_ids=None):  # pylint: disable=unused-argument
+        """Scheduler response."""
+        return [{"result": np.array([np.sum(x**2), np.sum(2 * x**2)])} for x in samples]
+
+    return scheduler_response
+
+
+def test_evaluate_with_grad_2d(default_fd_model, scheduler_response_2d):
+    """Test the evaluation method with gradient."""
+    default_fd_model.scheduler.evaluate = scheduler_response_2d
+    default_fd_model.evaluate_and_gradient_bool = True
+
     samples = np.random.random((3, 4))
 
+    expected_result = np.array([np.sum(samples**2, axis=1), np.sum(2 * samples**2, axis=1)]).T
     expected_grad = np.swapaxes(np.array([2 * samples, 4 * samples]), 0, 1)
-    expected_mean = np.array([np.sum(samples**2, axis=1), np.sum(2 * samples**2, axis=1)]).T
     response = default_fd_model.evaluate(samples)
-    np.testing.assert_array_almost_equal(expected_mean, response["result"], decimal=5)
+    np.testing.assert_array_almost_equal(expected_result, response["result"], decimal=5)
     np.testing.assert_array_almost_equal(expected_grad, response["gradient"], decimal=4)
     Model.evaluate_and_gradient_bool = False
 

--- a/tests/unit_tests/models/test_simulation.py
+++ b/tests/unit_tests/models/test_simulation.py
@@ -31,14 +31,25 @@ def test_init():
     assert model_obj.driver == driver
 
 
-def test_evaluate():
+@pytest.fixture(name="scheduler_response")
+def fixture_scheduler_response():
+    """Scheduler response fixture."""
+
+    def scheduler_response(samples, driver, job_ids=None):  # pylint: disable=unused-argument
+        """Scheduler response."""
+        return [{"result": x**2, "gradient": 2 * x} for x in samples]
+
+    return scheduler_response
+
+
+def test_evaluate(scheduler_response):
     """Test the evaluation method."""
     model_obj = Simulation(scheduler=Mock(), driver=Mock())
-    model_obj.scheduler.evaluate = lambda x, driver: {"mean": x**2, "gradient": 2 * x}
+    model_obj.scheduler.evaluate = scheduler_response
 
     samples = np.array([[2.0]])
     response = model_obj.evaluate(samples)
-    expected_response = {"mean": samples**2, "gradient": 2 * samples}
+    expected_response = {"result": samples**2, "gradient": 2 * samples}
     assert response == expected_response
     assert model_obj.response == expected_response
 


### PR DESCRIPTION
## Description and Context:<br> What and Why?
This PR moves the transformation of the driver outputs into a dict to the model out of the scheduler. Why:
- The scheduler does not necessarily return a numpy array, in case nothing is returned
- There is no limitation that the scheduler always returns the same size of array

This is again a backward-compatible change which improves flexibility in the same spirit as #237 and is a move towards making the scheduler independent of the QUEENS frontend, i.e., the model. The changes to the model were minimal, and the model will be refactored in the future, once the backend is finalish.

Note: I'm fairly certain the unit testing of the differentiable models was not testing what we expected. I changed it slightly.

## Related Issues and Pull Requests
* Closes
* Follows #237

## Interested Parties
@sbrandstaeter 

> Note: More information on the merge request procedure in QUEENS can be found in the [*Submit a pull request*](../CONTRIBUTING.md#5-submit-a-pull-request) section in the [CONTRIBUTING.md](../CONTRIBUTING.md) file.
