### PR TITLE
Make dataprocessor callable for the drivers

### DIFF
--- a/src/queens/data_processors/_data_processor.py
+++ b/src/queens/data_processors/_data_processor.py
@@ -17,6 +17,7 @@
 import abc
 import logging
 from pathlib import Path
+from typing import Any
 
 _logger = logging.getLogger(__name__)
 
@@ -90,14 +91,14 @@ class DataProcessor(metaclass=abc.ABCMeta):
         self.file_options_dict = file_options_dict
         self.file_name_identifier = file_name_identifier
 
-    def get_data_from_file(self, base_dir_file):
+    def get_data_from_file(self, base_dir_file: Path) -> Any:
         """Get data of interest from file.
 
         Args:
             base_dir_file (Path): Path of the base directory that contains the file of interest
 
         Returns:
-            processed_data (np.array): Final data from data processor module
+            processed_data (object): Final data from data processor module
         """
         if not base_dir_file:
             raise ValueError(
@@ -119,6 +120,17 @@ class DataProcessor(metaclass=abc.ABCMeta):
 
         self._clean_up(base_dir_file)
         return processed_data
+
+    def __call__(self, base_dir_file: Path) -> Any:
+        """Get data of interest from file.
+
+        Args:
+            base_dir_file (Path): Path of the base directory that contains the file of interest
+
+        Returns:
+            processed_data (object): Final data from data processor module
+        """
+        return self.get_data_from_file(base_dir_file)
 
     def _check_file_exist_and_is_unique(self, base_dir_file):
         """Check if file exists.

--- a/src/queens/drivers/jobscript.py
+++ b/src/queens/drivers/jobscript.py
@@ -16,6 +16,7 @@
 
 
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -92,8 +93,8 @@ class Jobscript(Driver):
         jobscript_template,
         executable,
         files_to_copy=None,
-        data_processor=None,
-        gradient_data_processor=None,
+        data_processor: Callable = None,
+        gradient_data_processor: Callable = None,
         jobscript_file_name="jobscript.sh",
         extra_options=None,
         raise_error_on_jobscript_failure=True,
@@ -305,12 +306,12 @@ class Jobscript(Driver):
         """
         result = None
         if self.data_processor:
-            result = self.data_processor.get_data_from_file(output_dir)
+            result = self.data_processor(output_dir)
             _logger.debug("Got result: %s", result)
 
         gradient = None
         if self.gradient_data_processor:
-            gradient = self.gradient_data_processor.get_data_from_file(output_dir)
+            gradient = self.gradient_data_processor(output_dir)
             _logger.debug("Got gradient: %s", gradient)
         return result, gradient
 

--- a/src/queens/drivers/mpi.py
+++ b/src/queens/drivers/mpi.py
@@ -43,8 +43,8 @@ class Mpi(Jobscript):
             input_templates (str, Path, dict): path to simulation input template
             executable (str, Path): path to main executable of respective software
             files_to_copy (list, opt): files or directories to copy to experiment_dir
-            data_processor (obj, opt): instance of data processor class
-            gradient_data_processor (obj, opt): instance of data processor class for gradient data
+            data_processor (Callable, opt): data processor
+            gradient_data_processor (Callable, opt): data processor class for gradient data
             mpi_cmd (str, opt): mpi command
         """
         # pylint: disable=duplicate-code

--- a/src/queens_interfaces/fourc/driver.py
+++ b/src/queens_interfaces/fourc/driver.py
@@ -49,8 +49,8 @@ class Fourc(Jobscript):
             input_templates (str, Path, dict): path to simulation input template
             executable (str, Path): path to main executable of respective software
             files_to_copy (list, opt): files or directories to copy to experiment_dir
-            data_processor (obj, opt): instance of data processor class
-            gradient_data_processor (obj, opt): instance of data processor class for gradient data
+            data_processor (Callable, opt): data processor
+            gradient_data_processor (Callable, opt): data processor class for gradient data
             post_processor (path, opt): path to post_processor
             post_options (str, opt): options for post-processing
             mpi_cmd (str, opt): mpi command


### PR DESCRIPTION
## Description and Context:<br> What and Why?
Same idea as #237. Due to historical reasons, we made them all objects, but there is actually no need. So now:
- The dataprocessors attributes in the drivers are callable, such that you can pass your custom function without having to go through the stiff dataprocessor structure
- Yes, the data processors do more stuff, like looking for the files and cleaning up (which should be done in the driver itself and is only done in the data processors due to the way the cluster setup was a long time ago)


The dataprocessors in general need a clean-up (move to composition instead of inheritance), as their class is much too stiff for current QUEENS approaches, and its design originates from a time QUEENS was a monolith (I'm not criticizing the design choices at the time, we always do our best), which we have evolved from since. This PR allows us to bypass this structure and allows us to refactor them independently. 

This is another step in untangling the inter-queen dependencies across modules, as it introduces flexibility at no additional cost for experts while maintaining backward compatibility for new users. 

For completeness: I'm not saying every user should rewrite their own functionality, quite the opposite, I think for (new) users it's always best to have easy and ready-to-use interfaces in/for QUEENS. I'm just saying that we can do both, provide default and common entries for users (without having to understand the backend) **and** customizable interface access for complex use cases (here you have to fully understand the backend, i.e., god mode). 

## Related Issues and Pull Requests
* Closes
* Related to #237

## Interested Parties


> Note: More information on the merge request procedure in QUEENS can be found in the [*Submit a pull request*](../CONTRIBUTING.md#5-submit-a-pull-request) section in the [CONTRIBUTING.md](../CONTRIBUTING.md) file.
