### PR TITLE
Draft: Simplify Parameter init for FreeVariables

### DIFF
--- a/src/queens/parameters/parameters.py
+++ b/src/queens/parameters/parameters.py
@@ -19,6 +19,7 @@ import logging
 import numpy as np
 
 from queens.distributions._distribution import Continuous, Discrete
+from queens.distributions.free_variable import FreeVariable
 from queens.parameters.random_fields._random_field import RandomField
 from queens.utils.logger_settings import log_init_args
 
@@ -60,15 +61,25 @@ class Parameters:
     """
 
     @log_init_args
-    def __init__(self, **parameters):
+    def __init__(self, *parameters_without_distribution, **parameters):
         """Initialize Parameters object.
 
         Args:
-            **parameters (Distribution, RandomField): parameters as keyword arguments
+            *parameters_without_distribution (str): Names of one-dimensional parameters without
+                                                    assumption about underlying distribution.
+            **parameters (Distribution, RandomField): parameters as keyword arguments. The keyword
+                                                      corresponds to the parameter name and the
+                                                      value corresponds to the underlying
+                                                      distribution.
         """
         joint_parameters_keys = []
         joint_parameters_dim = 0
         random_field_flag = False
+
+        for parameter_name in parameters_without_distribution:
+            if parameter_name in parameters:
+                raise ValueError(f"Parameter name {parameter_name} can only be used once.")
+            parameters[parameter_name] = FreeVariable(1)
 
         for parameter_name, parameter_obj in parameters.items():
             if isinstance(parameter_obj, (Continuous, Discrete)):

--- a/tests/integration_tests/iterators/test_optimization.py
+++ b/tests/integration_tests/iterators/test_optimization.py
@@ -34,9 +34,7 @@ from queens.utils.io import load_result
 def test_optimization_rosenbrock(algorithm, global_settings):
     """Test different solution algorithms in optimization iterator."""
     # Parameters
-    x1 = FreeVariable(dimension=1)
-    x2 = FreeVariable(dimension=1)
-    parameters = Parameters(x1=x1, x2=x2)
+    parameters = Parameters("x1", "x2")
 
     # Setup iterator
     driver = Function(parameters=parameters, function="rosenbrock60")


### PR DESCRIPTION
## Description and Context:<br> What and Why?
<!--
Provide a brief and concise description of your proposed change.
In particular: Why is this change required? What problem does it solve? Is this a breaking change?
-->
If someone wants to use queens for deterministic analyses, the setup of `Parameters` with `FreeVariable`s is a bit cumbersome. This PR aims to simplify this process by allowing `*args` for `Parameters` that are used for 1d parameters without underlying distributions. 

For example:
```python
from queens.distributions.free_variable import FreeVariable
x1 = FreeVariable(dimension=1)
x2 = FreeVariable(dimension=1)
parameters = Parameters(x1=x1, x2=x2)
```
can be simplified to 
```python
parameters = Parameters('x1', 'x2')
```



This is just a suggestion that might ignite ideas for a better solution :slightly_smiling_face: 

## Related Issues and Pull Requests
<!--
If applicable: how is this pull request related to other open issues or pull requests?
-->
* Closes
* Related to

## Interested Parties
<!--
If there's anyone you think should be looped in on this pull request,
feel free to @mention them here!
-->

> Note: More information on the merge request procedure in QUEENS can be found in the [*Submit a pull request*](../CONTRIBUTING.md#5-submit-a-pull-request) section in the [CONTRIBUTING.md](../CONTRIBUTING.md) file.
