### PR TITLE
ci: switch to 4c-minimal image

### DIFF
--- a/.github/workflows/tests_local.yml
+++ b/.github/workflows/tests_local.yml
@@ -31,7 +31,7 @@ jobs:
           sudo apt-get install -y rsync
       - name: Create links to 4C
         run: |
-          ln -s /home/user/4C/build/ config/4C_build
+          ln -s /home/user/4C/bin/ config/4C_build
       - name: Create Python environment
         id: environment
         uses: ./.github/actions/create_python_environment

--- a/test_utils/integration_tests.py
+++ b/test_utils/integration_tests.py
@@ -79,10 +79,8 @@ def get_input_park91a(n_inputs):
     return x_1_and_2, x_3, x_4
 
 
-def fourc_build_paths_from_home(home):
+def fourc_build_path_from_home(home):
     """Paths of 4C executables from home on testing machine."""
     fourc_build_path = home / "workspace/fourc_build"
     fourc = fourc_build_path / "4C"
-    post_ensight = fourc_build_path / "post_ensight"
-    post_processor = fourc_build_path / "post_processor"
-    return fourc, post_ensight, post_processor
+    return fourc

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -209,14 +209,12 @@ def fixture_config_dir():
     return config_dir_path
 
 
-@pytest.fixture(name="fourc_link_paths", scope="session")
-def fixture_fourc_link_paths(config_dir):
+@pytest.fixture(name="fourc_link", scope="session")
+def fixture_fourc_link(config_dir):
     """Set symbolic links for 4C on testing machine."""
     fourc_build_dir = config_dir / "4C_build"
     fourc = fourc_build_dir / "4C"
-    post_ensight = fourc_build_dir / "post_ensight"
-    post_processor = fourc_build_dir / "post_processor"
-    return fourc, post_ensight, post_processor
+    return fourc
 
 
 @pytest.fixture(name="example_simulator_fun_dir", scope="session")

--- a/tests/integration_tests/cluster/test_dask_cluster.py
+++ b/tests/integration_tests/cluster/test_dask_cluster.py
@@ -36,7 +36,7 @@ from queens.schedulers.cluster import Cluster
 from queens.utils.io import load_result
 from queens.utils.path import relative_path_from_root
 from queens.utils.remote_operations import RemoteConnection
-from test_utils.integration_tests import fourc_build_paths_from_home
+from test_utils.integration_tests import fourc_build_path_from_home
 
 _logger = logging.getLogger(__name__)
 
@@ -446,7 +446,7 @@ def fixture_fourc_cluster_path(remote_connection):
     result = remote_connection.run("echo ~", in_stream=False)
     remote_home = Path(result.stdout.rstrip())
 
-    fourc, _, _ = fourc_build_paths_from_home(remote_home)
+    fourc = fourc_build_path_from_home(remote_home)
 
     # Check for existence of 4C on remote machine.
     find_result = remote_connection.run(f"find {fourc}", in_stream=False)

--- a/tests/integration_tests/fourc/conftest.py
+++ b/tests/integration_tests/fourc/conftest.py
@@ -18,37 +18,19 @@ import pytest
 
 
 @pytest.fixture(name="setup_symbolic_links_fourc", autouse=True)
-def fixture_setup_symbolic_links_fourc(fourc_link_paths):
+def fixture_setup_symbolic_links_fourc(fourc_link):
     """Set-up of 4C symbolic links.
 
     Args:
-        fourc_link_paths (Path): Symbolic links to 4C executables.
+        fourc_link (Path): Symbolic link to 4C executable.
     """
-    (
-        fourc,
-        post_ensight,
-        post_processor,
-    ) = fourc_link_paths
-
     # check if symbolic links are existent
     try:
         # check if existing link to fourc works and points to a valid file
-        if not fourc.resolve().exists():
+        if not fourc_link.resolve().exists():
             raise FileNotFoundError(
-                f"The following link seems to be dead: {fourc}\n"
-                f"It points to (non-existing): {fourc.resolve()}\n"
-            )
-        # check if existing link to post_ensight works and points to a valid file
-        if not post_ensight.resolve().exists():
-            raise FileNotFoundError(
-                f"The following link seems to be dead: {post_ensight}\n"
-                f"It points to: {post_ensight.resolve()}\n"
-            )
-        # check if existing link to post_processor works and points to a valid file
-        if not post_processor.resolve().exists():
-            raise FileNotFoundError(
-                f"The following link seems to be dead: {post_processor}\n"
-                f"It points to: {post_processor.resolve()}\n"
+                f"The following link seems to be dead: {fourc_link}\n"
+                f"It points to (non-existing): {fourc_link.resolve()}\n"
             )
     except FileNotFoundError as error:
         raise FileNotFoundError(

--- a/tests/integration_tests/fourc/test_fourc_mc.py
+++ b/tests/integration_tests/fourc/test_fourc_mc.py
@@ -34,14 +34,13 @@ _logger = logging.getLogger(__name__)
 
 def test_fourc_mc(
     third_party_inputs,
-    fourc_link_paths,
+    fourc_link,
     fourc_example_expected_output,
     global_settings,
 ):
     """Test simple 4C run."""
     # generate json input file from template
     fourc_input_file_template = third_party_inputs / "fourc" / "solid_runtime_hex8.4C.yaml"
-    fourc_executable, _, _ = fourc_link_paths
 
     # Parameters
     parameter_1 = Uniform(lower_bound=0.0, upper_bound=1.0)
@@ -62,7 +61,7 @@ def test_fourc_mc(
     driver = Fourc(
         parameters=parameters,
         input_templates=fourc_input_file_template,
-        executable=fourc_executable,
+        executable=fourc_link,
         data_processor=data_processor,
     )
     model = Simulation(scheduler=scheduler, driver=driver)

--- a/tests/integration_tests/fourc/test_fourc_mc_random_material_field.py
+++ b/tests/integration_tests/fourc/test_fourc_mc_random_material_field.py
@@ -48,7 +48,7 @@ class DummyKLField(KarhunenLoeve):
 def test_write_random_elementwise_material(
     tmp_path,
     third_party_inputs,
-    fourc_link_paths,
+    fourc_link,
     expected_mean,
     global_settings,
 ):
@@ -56,8 +56,6 @@ def test_write_random_elementwise_material(
     fourc_input_template = third_party_inputs / "fourc" / "coarse_plate_dirichlet_template.4C.yaml"
 
     material_file_template = tmp_path / "material.json"
-
-    fourc_executable, post_ensight, _ = fourc_link_paths
 
     mue_rf_parameters = create_random_elemenentwise_material_field(
         fourc_input_template,
@@ -90,8 +88,7 @@ def test_write_random_elementwise_material(
             "input_file": fourc_input_template,
             "material_file": material_file_template,
         },
-        executable=fourc_executable,
-        post_processor=post_ensight,
+        executable=fourc_link,
         data_processor=data_processor,
     )
     model = Simulation(scheduler=scheduler, driver=driver)


### PR DESCRIPTION
## Description and Context:<br> What and Why?
<!--
Provide a brief and concise description of your proposed change.
In particular: Why is this change required? What problem does it solve? Is this a breaking change?
-->
This PR fixes our pipeline by switching to the 4C-minimal docker image, which requires a lot less storage space (compare https://github.com/4C-multiphysics/4C/pull/541).

Since 4C-minimal only contains the 4C executable and essentially nothing else, I have had to remove any dependencies on postpressors (`post_ensight`, `post_processor`) in our tests. These should no longer be needed to work with 4C anyway.

## Related Issues and Pull Requests
<!--
If applicable: how is this pull request related to other open issues or pull requests?
-->
* Closes
* Related to

## Interested Parties
<!--
If there's anyone you think should be looped in on this pull request,
feel free to @mention them here!
-->

> Note: More information on the merge request procedure in QUEENS can be found in the [*Submit a pull request*](../CONTRIBUTING.md#5-submit-a-pull-request) section in the [CONTRIBUTING.md](../CONTRIBUTING.md) file.
