### PR TITLE
Refactor manage paths

### DIFF
--- a/src/queens/drivers/jobscript.py
+++ b/src/queens/drivers/jobscript.py
@@ -271,12 +271,16 @@ class Jobscript(Driver):
 
         return results
 
-    def _manage_paths(self, job_id, experiment_dir):
+    def _manage_paths(
+        self, job_id, experiment_dir, output_folder_name="output", output_prefix="output"
+    ):
         """Manage paths for driver run.
 
         Args:
             job_id (int): Job ID.
             experiment_dir (Path): Path to QUEENS experiment directory.
+            output_folder_name (str): Name of output folder.
+            output_prefix (str): Prefix of output file(s).
 
         Returns:
             job_dir (Path): Path to job directory.
@@ -286,10 +290,9 @@ class Jobscript(Driver):
             log_file (Path): Path to log file.
         """
         job_dir = experiment_dir / str(job_id)
-        output_dir = job_dir / "output"
+        output_dir = job_dir / output_folder_name
         output_dir = create_folder_if_not_existent(output_dir)
 
-        output_prefix = "output"
         output_file = output_dir / output_prefix
         log_file = output_dir / (output_prefix + ".log")
 


### PR DESCRIPTION
## Description and Context:<br> What and Why?
<!--
Provide a brief and concise description of your proposed change.
In particular: Why is this change required? What problem does it solve? Is this a breaking change?
-->

This makes the `_manage_paths()` method a bit more flexible and avoids the default output names being hardcoded inside the function.

So far, both the name of the output directory and the name of the output files default to "output". This behaviour remains unchanged, but the values are now default arguments of the function. This makes it clearer what the hardcoded names are, and also allows them to be changed in derived classes.

## Related Issues and Pull Requests
<!--
If applicable: how is this pull request related to other open issues or pull requests?
-->
* Closes
* Related to #156 

## Interested Parties
<!--
If there's anyone you think should be looped in on this pull request,
feel free to @mention them here!
-->

> Note: More information on the merge request procedure in QUEENS can be found in the [*Submit a pull request*](../CONTRIBUTING.md#5-submit-a-pull-request) section in the [CONTRIBUTING.md](../CONTRIBUTING.md) file.
