### PR TITLE
Inject `sample_dict` into `jobscript_template`

### DIFF
--- a/src/queens/drivers/jobscript.py
+++ b/src/queens/drivers/jobscript.py
@@ -240,7 +240,7 @@ class Jobscript(Driver):
 
             # Create jobscript
             inject_in_template(
-                job_options.add_data_and_to_dict(self.jobscript_options),
+                job_options.add_data_and_to_dict(self.jobscript_options | sample_dict),
                 self.jobscript_template,
                 str(jobscript_file),
             )


### PR DESCRIPTION
## Description and Context:<br> What and Why?
<!--
Provide a brief and concise description of your proposed change.
In particular: Why is this change required? What problem does it solve? Is this a breaking change?
-->

This proposes to inject the `sample_dict` into `jobscript_template`, in principle the same way it is already injected into the `input_templates`. As mentioned in #255, I would like to use this for 4C restarts.

## Related Issues and Pull Requests
<!--
If applicable: how is this pull request related to other open issues or pull requests?
-->
* Closes #255 
* Related to

## Interested Parties
<!--
If there's anyone you think should be looped in on this pull request,
feel free to @mention them here!
-->
@tuchpaul, with this, you should no longer need the patch.

> Note: More information on the merge request procedure in QUEENS can be found in the [*Submit a pull request*](../CONTRIBUTING.md#5-submit-a-pull-request) section in the [CONTRIBUTING.md](../CONTRIBUTING.md) file.
