### PR TITLE
fix: fix cluster test that tests copying remote data to local machine

### DIFF
--- a/tests/integration_tests/cluster/test_dask_cluster.py
+++ b/tests/integration_tests/cluster/test_dask_cluster.py
@@ -293,14 +293,17 @@ class TestDaskCluster:
 
         # Now we test whether copying of the remote data worked correctly
 
-        # 1) we make sure that the result file is contained in the local copy
-        assert (local_data_path / "output-structure.pvd").exists()
+        local_experiment_path = local_data_path / global_settings.experiment_name
+        local_data = np.zeros_like(fourc_example_expected_output)
+        for i in range(2):
+            # 1) we make sure that the result files are contained in the local copy
+            output_path = local_experiment_path / str(i) / "output"
+            assert (output_path / "output-structure.pvd").exists()
 
-        # 2) and use a data processor to extract the data from the local copy of the remote data
-        local_data = data_processor(local_data_path)
+            # 2) and use a data processor to extract the data from the local copy of the remote data
+            local_data[i] = data_processor(output_path)
 
-        # if everything worked correctly, the data extracted this way should
-        # match the expected output
+        # The extracted local data should match the expected output
         np.testing.assert_array_almost_equal(local_data, fourc_example_expected_output, decimal=6)
 
     def delete_simulation_data(self, remote_connection):


### PR DESCRIPTION
## Description and Context:<br> What and Why?
<!--
Provide a brief and concise description of your proposed change.
In particular: Why is this change required? What problem does it solve? Is this a breaking change?
-->
This PR fixes the cluster test responsible for testing the new `copy_files_from_experiment_dir()` method. This method copies files from the remote experiment directory to the local machine.

The way the test has been implemented so far hasn't yet taken into account the file structure of the experiment directory. Therefore, our cluster tests have been failing.

I have tested the new implementation via a pipeline run on GitLab.

## Related Issues and Pull Requests
<!--
If applicable: how is this pull request related to other open issues or pull requests?
-->
* Closes
* Related to #269

## Interested Parties
<!--
If there's anyone you think should be looped in on this pull request,
feel free to @mention them here!
-->
@danielwolff1 

> Note: More information on the merge request procedure in QUEENS can be found in the [*Submit a pull request*](../CONTRIBUTING.md#5-submit-a-pull-request) section in the [CONTRIBUTING.md](../CONTRIBUTING.md) file.
