### PR TITLE
ci: add workflow that updates dependencies every 6 months

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "matchManagers": ["pip_requirements", "conda"],
+      "groupName": "Python dependencies",
+      "separateMajorMinor": false
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub actions",
+      "separateMajorMinor": false
+    }
+  ],
+  "dependencyDashboard": true
+  // "onboarding": false, // TODO: reactivate later
+  // "requireConfig": "optional" // TODO: reactivate later
+}

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -1,0 +1,21 @@
+name: update_dependencies
+on:
+    schedule:
+        - cron: "0 0 1 2 *" # 1st of February at 00:00 UTC
+        - cron: "0 0 1 8 *" # 1st of August at 00:00 UTC
+    push: # TODO: remove later, only for testing
+jobs:
+    run_renovate:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6.0.2
+            - name: Run self-hosted Renovate
+              uses: renovatebot/github-action@v44.2.5
+              with:
+                  #   token: ${{ secrets.RENOVATE_TOKEN }}
+                  token: ${{ secrets.RENOVATE_TOKEN_MY_QUEENS_FORK }}
+              env:
+                  #   RENOVATE_REPOSITORIES: "queens-py/queens"
+                  RENOVATE_REPOSITORIES: "leahaeusel/queens"
+                  RENOVATE_BRANCH_PREFIX: "renovate-action/"


### PR DESCRIPTION
## Description and Context:<br> What and Why?
<!--
Provide a brief and concise description of your proposed change.
In particular: Why is this change required? What problem does it solve? Is this a breaking change?
-->
This PR adds a workflow that automatically generates a PR that updates our dependencies every 6 months. It uses [renovate](https://github.com/renovatebot/renovate?tab=readme-ov-file) to do this.

## Related Issues and Pull Requests
<!--
If applicable: how is this pull request related to other open issues or pull requests?
-->
* Closes
* Related to #94

## Interested Parties
<!--
If there's anyone you think should be looped in on this pull request,
feel free to @mention them here!
-->
@maxdinkel 

> Note: More information on the merge request procedure in QUEENS can be found in the [*Submit a pull request*](../CONTRIBUTING.md#5-submit-a-pull-request) section in the [CONTRIBUTING.md](../CONTRIBUTING.md) file.
