### PR TITLE
Fix pipeline by installing setuptools<82

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,6 +19,9 @@ dependencies:
   - libopenblas==0.3.28
 # required for jupyter notebook integration into the sphinx documentation
   - pandoc
+# required because newer versions have deprecated the pkg_resources module, which is needed for
+# liccheck==0.9.2, gpflow==2.9.2
+  - setuptools<82
 # Only install pip-tools via pip itself since
 # all other pip dependencies should be managed
 # via pip-tools in the requirements.in files


### PR DESCRIPTION
## Description and Context:<br> What and Why?
<!--
Provide a brief and concise description of your proposed change.
In particular: Why is this change required? What problem does it solve? Is this a breaking change?
-->
This PR fixes our pipeline by enforcing a setuptools version smaller than 82. Newer setuptools versions have deprecated the pkg_resources module, which causes our dependencies liccheck and gpflow (and possibly others) to raise an error.

This is only a quick fix. In the long run, we should
1. update our dependencies (maybe newer versions of gpflow don't rely on pkg_resources anymore)
2. find an alternative for liccheck as it doesn't seem to be maintained anymore (last update Sept. 2023)

## Related Issues and Pull Requests
<!--
If applicable: how is this pull request related to other open issues or pull requests?
-->
* Closes
* Related to

## Interested Parties
<!--
If there's anyone you think should be looped in on this pull request,
feel free to @mention them here!
-->

> Note: More information on the merge request procedure in QUEENS can be found in the [*Submit a pull request*](../CONTRIBUTING.md#5-submit-a-pull-request) section in the [CONTRIBUTING.md](../CONTRIBUTING.md) file.
