### PR TITLE
feat(distributions): add truncated normal distribution

### DIFF
--- a/src/queens/distributions/__init__.py
+++ b/src/queens/distributions/__init__.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
     from queens.distributions.multinomial import Multinomial
     from queens.distributions.normal import Normal
     from queens.distributions.particle import Particle
+    from queens.distributions.truncated_normal import TruncatedNormal
     from queens.distributions.uniform import Uniform
     from queens.distributions.uniform_discrete import UniformDiscrete
 

--- a/src/queens/distributions/truncated_normal.py
+++ b/src/queens/distributions/truncated_normal.py
@@ -30,47 +30,56 @@ class TruncatedNormal(Continuous):
     mean and std of the underlying (unbounded) normal distribution.
 
     Internally, scipy.stats.truncnorm is used with standardized bounds
-    a = (lower_bound - mean) / std and b = (upper_bound - mean) / std.
+    a = (lower_bound - unbounded_mean) / unbounded_std and
+    b = (upper_bound - unbounded_mean) / unbounded_std.
 
     Attributes:
-        mu: Mean of the underlying (unbounded) normal distribution.
-        sigma: Standard deviation of the underlying (unbounded) normal distribution.
+        unbounded_mean: Mean of the underlying (unbounded) normal distribution.
+        unbounded_std: Standard deviation of the underlying (unbounded) normal distribution.
         lower_bound: Lower bound of the distribution.
         upper_bound: Upper bound of the distribution.
         scipy_truncnorm: Scipy truncated normal distribution object.
+        mean: (inherited) Mean of the truncated distribution, computed via scipy.
+        covariance: (inherited) Variance of the truncated distribution, computed via scipy.
+        dimension: (inherited) Dimensionality of the distribution (always 1).
     """
 
     @log_init_args
     def __init__(
-        self, mean: ArrayLike, std: ArrayLike, lower_bound: ArrayLike, upper_bound: ArrayLike
+        self,
+        unbounded_mean: ArrayLike,
+        unbounded_std: ArrayLike,
+        lower_bound: ArrayLike,
+        upper_bound: ArrayLike,
     ) -> None:
         """Initialize truncated normal distribution.
 
         Args:
-            mean: Mean of the underlying (unbounded) normal distribution.
-            std: Standard deviation of the underlying normal distribution. Must be positive.
+            unbounded_mean: Mean of the underlying (unbounded) normal distribution.
+            unbounded_std: Standard deviation of the underlying (unbounded) normal distribution.
+                Must be positive.
             lower_bound: Lower bound of the distribution. Must be smaller than upper_bound.
             upper_bound: Upper bound of the distribution.
         """
-        mu = np.array(mean).reshape(-1)
-        sigma = np.array(std).reshape(-1)
+        unbounded_mean = np.array(unbounded_mean).reshape(-1)
+        unbounded_std = np.array(unbounded_std).reshape(-1)
         lower_bound = np.array(lower_bound).reshape(-1)
         upper_bound = np.array(upper_bound).reshape(-1)
 
-        if max(mu.size, sigma.size, lower_bound.size, upper_bound.size) != 1:
+        if max(unbounded_mean.size, unbounded_std.size, lower_bound.size, upper_bound.size) != 1:
             raise NotImplementedError(
                 "Only one-dimensional truncated normal distributions are supported."
             )
 
-        super().check_positivity(std=sigma)
+        super().check_positivity(unbounded_std=unbounded_std)
         super().check_bounds(lower_bound, upper_bound)
 
-        a = (lower_bound - mu) / sigma
-        b = (upper_bound - mu) / sigma
-        scipy_truncnorm = scipy.stats.truncnorm(a, b, loc=mu, scale=sigma)
+        a = (lower_bound - unbounded_mean) / unbounded_std
+        b = (upper_bound - unbounded_mean) / unbounded_std
+        scipy_truncnorm = scipy.stats.truncnorm(a, b, loc=unbounded_mean, scale=unbounded_std)
 
-        self.mu = mu
-        self.sigma = sigma
+        self.unbounded_mean = unbounded_mean
+        self.unbounded_std = unbounded_std
         self.lower_bound = lower_bound
         self.upper_bound = upper_bound
         self.scipy_truncnorm = scipy_truncnorm
@@ -127,7 +136,7 @@ class TruncatedNormal(Continuous):
             Gradient of the log-PDF at positions
         """
         x = np.asarray(x).reshape(-1)
-        grad_logpdf = (self.mu - x) / self.sigma**2
+        grad_logpdf = (self.unbounded_mean - x) / self.unbounded_std**2
         return grad_logpdf
 
     def pdf(self, x: np.ndarray) -> np.ndarray:

--- a/src/queens/distributions/truncated_normal.py
+++ b/src/queens/distributions/truncated_normal.py
@@ -1,0 +1,155 @@
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (c) 2024-2025, QUEENS contributors.
+#
+# This file is part of QUEENS.
+#
+# QUEENS is free software: you can redistribute it and/or modify it under the terms of the GNU
+# Lesser General Public License as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version. QUEENS is distributed in the hope that it will
+# be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details. You
+# should have received a copy of the GNU Lesser General Public License along with QUEENS. If not,
+# see <https://www.gnu.org/licenses/>.
+#
+"""Truncated normal distribution."""
+
+import numpy as np
+import scipy.stats
+from numpy.typing import ArrayLike
+
+from queens.distributions._distribution import Continuous
+from queens.utils.logger_settings import log_init_args
+
+
+class TruncatedNormal(Continuous):
+    """Truncated normal distribution.
+
+    A one-dimensional normal distribution restricted to the finite interval
+    [lower_bound, upper_bound]. The distribution is parametrized by the
+    mean and std of the underlying (unbounded) normal distribution.
+
+    Internally, scipy.stats.truncnorm is used with standardized bounds
+    a = (lower_bound - mean) / std and b = (upper_bound - mean) / std.
+
+    Attributes:
+        mu: Mean of the underlying (unbounded) normal distribution.
+        sigma: Standard deviation of the underlying (unbounded) normal distribution.
+        lower_bound: Lower bound of the distribution.
+        upper_bound: Upper bound of the distribution.
+        scipy_truncnorm: Scipy truncated normal distribution object.
+    """
+
+    @log_init_args
+    def __init__(
+        self, mean: ArrayLike, std: ArrayLike, lower_bound: ArrayLike, upper_bound: ArrayLike
+    ) -> None:
+        """Initialize truncated normal distribution.
+
+        Args:
+            mean: Mean of the underlying (unbounded) normal distribution.
+            std: Standard deviation of the underlying normal distribution. Must be positive.
+            lower_bound: Lower bound of the distribution. Must be smaller than upper_bound.
+            upper_bound: Upper bound of the distribution.
+        """
+        mu = np.array(mean).reshape(-1)
+        sigma = np.array(std).reshape(-1)
+        lower_bound = np.array(lower_bound).reshape(-1)
+        upper_bound = np.array(upper_bound).reshape(-1)
+
+        if max(mu.size, sigma.size, lower_bound.size, upper_bound.size) != 1:
+            raise NotImplementedError(
+                "Only one-dimensional truncated normal distributions are supported."
+            )
+
+        super().check_positivity(std=sigma)
+        super().check_bounds(lower_bound, upper_bound)
+
+        a = (lower_bound - mu) / sigma
+        b = (upper_bound - mu) / sigma
+        scipy_truncnorm = scipy.stats.truncnorm(a, b, loc=mu, scale=sigma)
+
+        self.mu = mu
+        self.sigma = sigma
+        self.lower_bound = lower_bound
+        self.upper_bound = upper_bound
+        self.scipy_truncnorm = scipy_truncnorm
+
+        super().__init__(
+            mean=scipy_truncnorm.mean(),
+            covariance=scipy_truncnorm.var(),
+            dimension=1,
+        )
+
+    def cdf(self, x: np.ndarray) -> np.ndarray:
+        """Cumulative distribution function.
+
+        Args:
+            x: Positions at which the CDF is evaluated
+
+        Returns:
+            CDF at positions
+        """
+        cdf = self.scipy_truncnorm.cdf(x).reshape(-1)
+        return cdf
+
+    def draw(self, num_draws: int = 1) -> np.ndarray:
+        """Draw samples.
+
+        Args:
+            num_draws: Number of draws
+
+        Returns:
+            Drawn samples from the distribution
+        """
+        samples = self.scipy_truncnorm.rvs(size=num_draws).reshape(-1, 1)
+        return samples
+
+    def logpdf(self, x: np.ndarray) -> np.ndarray:
+        """Log of the probability density function.
+
+        Args:
+            x: Positions at which the log-PDF is evaluated
+
+        Returns:
+            Log-PDF at positions
+        """
+        logpdf = self.scipy_truncnorm.logpdf(x).reshape(-1)
+        return logpdf
+
+    def grad_logpdf(self, x: np.ndarray) -> np.ndarray:
+        """Gradient of the log-PDF with respect to x.
+
+        Args:
+            x: Positions at which the gradient of the log-PDF is evaluated
+
+        Returns:
+            Gradient of the log-PDF at positions
+        """
+        x = np.asarray(x).reshape(-1)
+        grad_logpdf = (self.mu - x) / self.sigma**2
+        return grad_logpdf
+
+    def pdf(self, x: np.ndarray) -> np.ndarray:
+        """Probability density function.
+
+        Args:
+            x: Positions at which the PDF is evaluated
+
+        Returns:
+            PDF at positions
+        """
+        pdf = self.scipy_truncnorm.pdf(x).reshape(-1)
+        return pdf
+
+    def ppf(self, quantiles: np.ndarray) -> np.ndarray:
+        """Percent point function (inverse of CDF — quantiles).
+
+        Args:
+            quantiles: Quantiles at which the PPF is evaluated
+
+        Returns:
+            Positions which correspond to given quantiles
+        """
+        ppf = self.scipy_truncnorm.ppf(quantiles).reshape(-1)
+        return ppf

--- a/tests/unit_tests/distributions/test_truncated_normal.py
+++ b/tests/unit_tests/distributions/test_truncated_normal.py
@@ -1,0 +1,159 @@
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (c) 2024-2025, QUEENS contributors.
+#
+# This file is part of QUEENS.
+#
+# QUEENS is free software: you can redistribute it and/or modify it under the terms of the GNU
+# Lesser General Public License as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version. QUEENS is distributed in the hope that it will
+# be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details. You
+# should have received a copy of the GNU Lesser General Public License along with QUEENS. If not,
+# see <https://www.gnu.org/licenses/>.
+#
+"""Test-module for truncated normal distribution."""
+
+import numpy as np
+import pytest
+import scipy.stats
+
+from queens.distributions.truncated_normal import TruncatedNormal
+
+
+@pytest.fixture(name="sample_pos", params=[0.25, [0.1, 0.25, 0.4, 0.5]])
+def fixture_sample_pos(request):
+    """Sample position to be evaluated."""
+    return np.array(request.param)
+
+
+@pytest.fixture(name="normal_mean", scope="module")
+def fixture_normal_mean():
+    """Mean of the underlying normal distribution."""
+    return 0.3
+
+
+@pytest.fixture(name="normal_std", scope="module")
+def fixture_normal_std():
+    """Standard deviation of the underlying normal distribution."""
+    return 0.05
+
+
+@pytest.fixture(name="lower_bound", scope="module")
+def fixture_lower_bound():
+    """Lower bound of the distribution."""
+    return 0.1
+
+
+@pytest.fixture(name="upper_bound", scope="module")
+def fixture_upper_bound():
+    """Upper bound of the distribution."""
+    return 0.45
+
+
+@pytest.fixture(name="truncated_normal", scope="module")
+def fixture_truncated_normal(normal_mean, normal_std, lower_bound, upper_bound):
+    """A truncated normal distribution."""
+    return TruncatedNormal(
+        mean=normal_mean, std=normal_std, lower_bound=lower_bound, upper_bound=upper_bound
+    )
+
+
+@pytest.fixture(name="scipy_reference", scope="module")
+def fixture_scipy_reference(normal_mean, normal_std, lower_bound, upper_bound):
+    """Reference scipy frozen truncnorm for comparison."""
+    a = (lower_bound - normal_mean) / normal_std
+    b = (upper_bound - normal_mean) / normal_std
+    return scipy.stats.truncnorm(a, b, loc=normal_mean, scale=normal_std)
+
+
+# -----------------------------------------------------------------------
+# ---------------------------- TESTS ------------------------------------
+# -----------------------------------------------------------------------
+
+
+def test_init_truncated_normal(
+    truncated_normal, normal_mean, normal_std, lower_bound, upper_bound, scipy_reference
+):
+    """Test init method of TruncatedNormal distribution class."""
+    assert truncated_normal.dimension == 1
+    np.testing.assert_equal(truncated_normal.mu, np.array(normal_mean).reshape(-1))
+    np.testing.assert_equal(truncated_normal.sigma, np.array(normal_std).reshape(-1))
+    np.testing.assert_equal(truncated_normal.lower_bound, np.array(lower_bound).reshape(-1))
+    np.testing.assert_equal(truncated_normal.upper_bound, np.array(upper_bound).reshape(-1))
+    np.testing.assert_equal(truncated_normal.mean, scipy_reference.mean())
+    np.testing.assert_equal(truncated_normal.covariance, scipy_reference.var())
+
+
+def test_init_truncated_normal_wrong_interval(normal_mean, normal_std):
+    """Test init with lower bound greater than upper bound."""
+    with pytest.raises(ValueError, match=r"Lower bound must be smaller than upper bound*"):
+        TruncatedNormal(mean=normal_mean, std=normal_std, lower_bound=0.5, upper_bound=0.1)
+
+
+def test_init_truncated_normal_negative_std(normal_mean, lower_bound, upper_bound):
+    """Test init with non-positive std."""
+    with pytest.raises(ValueError, match=r"The parameter \'std\' has to be positive.*"):
+        TruncatedNormal(
+            mean=normal_mean, std=-0.1, lower_bound=lower_bound, upper_bound=upper_bound
+        )
+
+
+def test_init_truncated_normal_multivariate(normal_std, lower_bound, upper_bound):
+    """Test init with multivariate mean raises NotImplementedError."""
+    with pytest.raises(NotImplementedError, match=r"Only one-dimensional*"):
+        TruncatedNormal(
+            mean=[0.3, 0.4], std=normal_std, lower_bound=lower_bound, upper_bound=upper_bound
+        )
+
+
+def test_cdf_truncated_normal(truncated_normal, sample_pos, scipy_reference):
+    """Test cdf method of truncated normal distribution class."""
+    ref_sol = scipy_reference.cdf(sample_pos).reshape(-1)
+    np.testing.assert_equal(truncated_normal.cdf(sample_pos), ref_sol)
+
+
+def test_draw_truncated_normal(truncated_normal, mocker):
+    """Test the draw method of truncated normal distribution."""
+    sample = np.asarray(0.3).reshape(1, 1)
+    mocker.patch("scipy.stats._distn_infrastructure.rv_frozen.rvs", return_value=sample)
+    draw = truncated_normal.draw()
+    np.testing.assert_equal(draw, sample)
+
+
+def test_logpdf_truncated_normal(truncated_normal, sample_pos, scipy_reference):
+    """Test logpdf method of truncated normal distribution class."""
+    ref_sol = scipy_reference.logpdf(sample_pos).reshape(-1)
+    np.testing.assert_equal(truncated_normal.logpdf(sample_pos), ref_sol)
+
+
+def test_pdf_truncated_normal(truncated_normal, sample_pos, scipy_reference):
+    """Test pdf method of truncated normal distribution class."""
+    ref_sol = scipy_reference.pdf(sample_pos).reshape(-1)
+    np.testing.assert_equal(truncated_normal.pdf(sample_pos), ref_sol)
+
+
+def test_grad_logpdf_truncated_normal(truncated_normal, normal_mean, normal_std, sample_pos):
+    """Test grad_logpdf against analytical formula -(x - mean) / std**2."""
+    x = np.asarray(sample_pos).reshape(-1)
+    ref_sol = (normal_mean - x) / normal_std**2
+    np.testing.assert_allclose(truncated_normal.grad_logpdf(sample_pos), ref_sol)
+
+
+def test_grad_logpdf_matches_numerical(truncated_normal):
+    """Test grad_logpdf matches numerical differentiation of logpdf."""
+    eps = 1e-6
+    for xi in (0.2, 0.3, 0.4):
+        numerical = (
+            truncated_normal.logpdf(np.array([xi + eps]))[0]
+            - truncated_normal.logpdf(np.array([xi - eps]))[0]
+        ) / (2 * eps)
+        analytical = truncated_normal.grad_logpdf(np.array([xi]))[0]
+        np.testing.assert_allclose(analytical, numerical, rtol=1e-5)
+
+
+def test_ppf_truncated_normal(truncated_normal, scipy_reference):
+    """Test ppf method of truncated normal distribution class."""
+    quantile = 0.5
+    ref_sol = scipy_reference.ppf(quantile).reshape(-1)
+    np.testing.assert_equal(truncated_normal.ppf(quantile), ref_sol)

--- a/tests/unit_tests/distributions/test_truncated_normal.py
+++ b/tests/unit_tests/distributions/test_truncated_normal.py
@@ -55,7 +55,10 @@ def fixture_upper_bound():
 def fixture_truncated_normal(normal_mean, normal_std, lower_bound, upper_bound):
     """A truncated normal distribution."""
     return TruncatedNormal(
-        mean=normal_mean, std=normal_std, lower_bound=lower_bound, upper_bound=upper_bound
+        unbounded_mean=normal_mean,
+        unbounded_std=normal_std,
+        lower_bound=lower_bound,
+        upper_bound=upper_bound,
     )
 
 
@@ -77,8 +80,8 @@ def test_init_truncated_normal(
 ):
     """Test init method of TruncatedNormal distribution class."""
     assert truncated_normal.dimension == 1
-    np.testing.assert_equal(truncated_normal.mu, np.array(normal_mean).reshape(-1))
-    np.testing.assert_equal(truncated_normal.sigma, np.array(normal_std).reshape(-1))
+    np.testing.assert_equal(truncated_normal.unbounded_mean, np.array(normal_mean).reshape(-1))
+    np.testing.assert_equal(truncated_normal.unbounded_std, np.array(normal_std).reshape(-1))
     np.testing.assert_equal(truncated_normal.lower_bound, np.array(lower_bound).reshape(-1))
     np.testing.assert_equal(truncated_normal.upper_bound, np.array(upper_bound).reshape(-1))
     np.testing.assert_equal(truncated_normal.mean, scipy_reference.mean())
@@ -88,14 +91,22 @@ def test_init_truncated_normal(
 def test_init_truncated_normal_wrong_interval(normal_mean, normal_std):
     """Test init with lower bound greater than upper bound."""
     with pytest.raises(ValueError, match=r"Lower bound must be smaller than upper bound*"):
-        TruncatedNormal(mean=normal_mean, std=normal_std, lower_bound=0.5, upper_bound=0.1)
+        TruncatedNormal(
+            unbounded_mean=normal_mean,
+            unbounded_std=normal_std,
+            lower_bound=0.5,
+            upper_bound=0.1,
+        )
 
 
 def test_init_truncated_normal_negative_std(normal_mean, lower_bound, upper_bound):
     """Test init with non-positive std."""
-    with pytest.raises(ValueError, match=r"The parameter \'std\' has to be positive.*"):
+    with pytest.raises(ValueError, match=r"The parameter \'unbounded_std\' has to be positive.*"):
         TruncatedNormal(
-            mean=normal_mean, std=-0.1, lower_bound=lower_bound, upper_bound=upper_bound
+            unbounded_mean=normal_mean,
+            unbounded_std=-0.1,
+            lower_bound=lower_bound,
+            upper_bound=upper_bound,
         )
 
 
@@ -103,7 +114,10 @@ def test_init_truncated_normal_multivariate(normal_std, lower_bound, upper_bound
     """Test init with multivariate mean raises NotImplementedError."""
     with pytest.raises(NotImplementedError, match=r"Only one-dimensional*"):
         TruncatedNormal(
-            mean=[0.3, 0.4], std=normal_std, lower_bound=lower_bound, upper_bound=upper_bound
+            unbounded_mean=[0.3, 0.4],
+            unbounded_std=normal_std,
+            lower_bound=lower_bound,
+            upper_bound=upper_bound,
         )
 
 


### PR DESCRIPTION
## Description and Context: What and Why?

Adds a 1D truncated normal distribution to QUEENS. This distribution is
commonly needed in UQ for engineering parameters that are approximately
Gaussian but physically bounded — e.g. the Poisson ratio of carbon fibers
(mean ≈ 0.3, bounded to (0.1, 0.45) to avoid unphysical values near 0.5).

The implementation wraps `scipy.stats.truncnorm` with standardized bounds
`a = (lower - mean) / std`, `b = (upper - mean) / std`. The
`grad_logpdf` is implemented analytically: since the truncation constant
does not depend on `x`, the gradient on the open interval equals that of
the unbounded normal (`-(x - μ) / σ²`).

## Related Issues and Pull Requests
* Closes #299

## Interested Parties
@leahaeusel — thanks for sharing the starting skeleton in the issue!
