### PR TITLE
ci: remove verbose flag to keep collecting log output

### DIFF
--- a/.gitlab/.gitlab-ci.yml
+++ b/.gitlab/.gitlab-ci.yml
@@ -248,7 +248,8 @@ charon-build_pixi_env:
           $LOAD_MODULES \
           module list ; \
           cd ~/workspace ; \
-          rm -rfv fourc_source fourc_build ; \
+          rm -rf fourc_source fourc_build ; \
+          echo Removed folders fourc_source and fourc_build ; \
           git clone --depth 1 https://github.com/4C-multiphysics/4C.git fourc_source ; \
           mkdir fourc_build ; \
           cd fourc_build ; \


### PR DESCRIPTION
## Description and Context:<br> What and Why?
<!--
Provide a brief and concise description of your proposed change.
In particular: Why is this change required? What problem does it solve? Is this a breaking change?
-->
To facilitate debugging the GitLab pipeline, I suggest removing the verbose flag of the `rm` command.

Running this command in verbose mode causes the log to exceed its limit while building 4C, which makes debugging this job difficult:
<img width="934" height="195" alt="image" src="https://github.com/user-attachments/assets/5561e4ee-11e8-4167-a59a-b7e1baecc601" />


## Related Issues and Pull Requests
<!--
If applicable: how is this pull request related to other open issues or pull requests?
-->
* Closes
* Related to

## Interested Parties
<!--
If there's anyone you think should be looped in on this pull request,
feel free to @mention them here!
-->

> Note: More information on the merge request procedure in QUEENS can be found in the [*Submit a pull request*](../CONTRIBUTING.md#5-submit-a-pull-request) section in the [CONTRIBUTING.md](../CONTRIBUTING.md) file.
