### PR TITLE
Add gaussian kde distribution wrapper

### DIFF
--- a/src/queens/distributions/__init__.py
+++ b/src/queens/distributions/__init__.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from queens.distributions.categorical import Categorical
     from queens.distributions.exponential import Exponential
     from queens.distributions.free_variable import FreeVariable
+    from queens.distributions.gaussian_kde import GaussianKDE
     from queens.distributions.lognormal import LogNormal
     from queens.distributions.mean_field_normal import MeanFieldNormal
     from queens.distributions.multinomial import Multinomial

--- a/src/queens/distributions/gaussian_kde.py
+++ b/src/queens/distributions/gaussian_kde.py
@@ -1,0 +1,187 @@
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (c) 2024-2025, QUEENS contributors.
+#
+# This file is part of QUEENS.
+#
+# QUEENS is free software: you can redistribute it and/or modify it under the terms of the GNU
+# Lesser General Public License as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version. QUEENS is distributed in the hope that it will
+# be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details. You
+# should have received a copy of the GNU Lesser General Public License along with QUEENS. If not,
+# see <https://www.gnu.org/licenses/>.
+#
+"""Gaussian kernel density estimate distribution."""
+
+from __future__ import annotations
+
+from typing import Any, override
+
+import numpy as np
+from numpy.typing import ArrayLike
+from scipy.stats import gaussian_kde
+from sklearn.cluster import KMeans
+
+from queens.distributions._distribution import Continuous
+from queens.utils.logger_settings import log_init_args
+
+
+class GaussianKDE(Continuous):
+    """(Multivariate) Gaussian kernel density estimate distribution.
+
+    This wraps ``scipy.stats.gaussian_kde`` to allow its use in QUEENS.
+    """
+
+    @log_init_args
+    def __init__(
+        self,
+        samples: ArrayLike,
+        weights: ArrayLike | None = None,
+        bandwidth: Any | None = None,
+    ) -> None:
+        """Initialize a Gaussian kernel density estimate distribution.
+
+        Args:
+            samples: Samples used to estimate the density, with one sample per row.
+            weights: Non-negative sample weights. They don't need to be normalized.
+            bandwidth: KDE bandwidth method. See ``scipy.stats.gaussian_kde`` for available options.
+        """
+        samples = np.asarray(samples)
+        if samples.ndim == 1:
+            samples = samples.reshape(-1, 1)
+        if samples.ndim != 2:
+            raise ValueError("Samples must be a one- or two-dimensional array.")
+        self._check_number_of_kernels(samples.shape[0], samples.shape[1])
+
+        weights_array = None if weights is None else np.asarray(weights).reshape(-1)
+        if weights_array is not None:
+            if weights_array.size != samples.shape[0]:
+                raise ValueError("Number of weights does not match the number of samples.")
+
+        self.samples = samples
+        self.bandwidth = bandwidth
+        # create the scipy gaussian_kde object
+        self.scipy_kde = gaussian_kde(
+            samples.T,
+            weights=weights_array,
+            bw_method=bandwidth,
+        )
+        # get the normalized weights
+        self.weights = self.scipy_kde.weights
+
+        mean = np.average(samples, axis=0, weights=self.weights)
+        sample_covariance = np.einsum("n,ni,nj->ij", self.weights, samples - mean, samples - mean)
+        covariance = sample_covariance + self.scipy_kde.covariance
+        super().__init__(mean=mean, covariance=covariance, dimension=samples.shape[1])
+
+    @override
+    def cdf(self, x: np.ndarray) -> np.ndarray:
+        x = self._as_points(x)
+        lower = np.full(self.dimension, -np.inf)
+        return np.array(
+            [self.scipy_kde.integrate_box(low_bounds=lower, high_bounds=point) for point in x]
+        )
+
+    @override
+    def draw(self, num_draws: int = 1) -> np.ndarray:
+        return self.scipy_kde.resample(size=num_draws).T
+
+    @override
+    def logpdf(self, x: np.ndarray) -> np.ndarray:
+        x = self._as_points(x)
+        return self.scipy_kde.logpdf(x.T)
+
+    @override
+    def pdf(self, x: np.ndarray) -> np.ndarray:
+        x = self._as_points(x)
+        return self.scipy_kde.pdf(x.T)
+
+    @override
+    def grad_logpdf(self, x: np.ndarray) -> np.ndarray:
+        raise NotImplementedError(
+            "Gradient of logpdf not available for Gaussian KDE distributions."
+        )
+
+    @override
+    def ppf(self, quantiles: np.ndarray) -> np.ndarray:
+        raise NotImplementedError("ppf not available for Gaussian KDE distributions.")
+
+    def downsample(
+        self,
+        max_kernels: int,
+        random_state: int | None = None,
+    ) -> GaussianKDE:
+        """Downsample the KDE using weighted cluster centers.
+
+        Args:
+            max_kernels: Maximum number of kernels in the reduced KDE.
+            random_state: Seed used for the k-means initialization.
+
+        Returns:
+            Weighted reduced Gaussian KDE, or this KDE if it already has at most ``max_kernels``
+            kernels.
+        """
+        self._check_number_of_kernels(max_kernels, self.dimension)
+        if self.samples.shape[0] <= max_kernels:
+            return self
+
+        kmeans = KMeans(n_clusters=max_kernels, random_state=random_state, n_init="auto")
+        kmeans.fit(self.samples, sample_weight=self.weights)
+
+        reduced_samples = []
+        reduced_weights = []
+        for cluster_label in range(max_kernels):
+            samples_in_cluster_mask = kmeans.labels_ == cluster_label
+            if not np.any(samples_in_cluster_mask):
+                continue  # empty cluster
+
+            cluster_weights = self.weights[samples_in_cluster_mask]
+            # average over all samples in the cluster, weighted by their original weights
+            # to determine the new reduced kernel location of this cluster
+            reduced_samples.append(
+                np.average(self.samples[samples_in_cluster_mask], axis=0, weights=cluster_weights)
+            )
+            reduced_weights.append(np.sum(cluster_weights))
+
+        return GaussianKDE(
+            np.array(reduced_samples),
+            weights=np.array(reduced_weights),
+            bandwidth=self.scipy_kde.factor,
+        )
+
+    @staticmethod
+    def _check_number_of_kernels(number_of_kernels: int, dimension: int) -> None:
+        """Ensure number of kernels is larger than the distribution dimension.
+
+        Args:
+            number_of_kernels: Number of kernels in the KDE.
+            dimension: Dimension of the distribution.
+        """
+        if number_of_kernels <= dimension:
+            raise ValueError("Number of kernels must be larger than the distribution dimension.")
+
+    def _as_points(self, x: ArrayLike) -> np.ndarray:
+        """Convert one point or a batch of points to row-wise shape.
+
+        Args:
+            x: One point or a batch of points to evaluate the distribution at.
+
+        Returns:
+            The points in row-wise shape: ``(n_points, dimension)``.
+        """
+        x = np.asarray(x, dtype=float)
+        if x.ndim == 0 and self.dimension == 1:
+            return x.reshape(1, 1)
+        if x.ndim == 1:
+            if self.dimension == 1:
+                return x.reshape(-1, 1)
+            if x.size == self.dimension:
+                return x.reshape(1, self.dimension)
+        elif x.ndim == 2 and x.shape[1] == self.dimension:
+            return x
+
+        raise ValueError(
+            "Evaluation points must have shape "
+            f"({self.dimension},) or (n_points, {self.dimension})."
+        )

--- a/tests/unit_tests/distributions/test_gaussian_kde.py
+++ b/tests/unit_tests/distributions/test_gaussian_kde.py
@@ -1,0 +1,224 @@
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (c) 2024-2025, QUEENS contributors.
+#
+# This file is part of QUEENS.
+#
+# QUEENS is free software: you can redistribute it and/or modify it under the terms of the GNU
+# Lesser General Public License as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version. QUEENS is distributed in the hope that it will
+# be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details. You
+# should have received a copy of the GNU Lesser General Public License along with QUEENS. If not,
+# see <https://www.gnu.org/licenses/>.
+#
+"""Tests for the Gaussian KDE distribution."""
+
+import numpy as np
+import pytest
+
+from queens.distributions.gaussian_kde import GaussianKDE
+
+
+@pytest.fixture(name="gaussian_kde")
+def fixture_distribution():
+    """Create a weighted two-dimensional Gaussian KDE."""
+    samples = np.array([[-1.0, 0.0], [0.0, 1.0], [1.0, -0.5], [2.0, 1.5]])
+    weights = np.array([0.1, 0.2, 0.3, 0.4])
+    return GaussianKDE(samples, weights=weights)
+
+
+def test_pdf(gaussian_kde: GaussianKDE):
+    """Test that pdf matches the underlying scipy implementation."""
+    points = np.array([[-0.5, 0.2], [0.5, 0.7], [1.5, 1.0]])
+    np.testing.assert_allclose(gaussian_kde.pdf(points), gaussian_kde.scipy_kde.pdf(points.T))
+
+
+def test_logpdf(gaussian_kde: GaussianKDE):
+    """Test that logpdf matches the underlying scipy implementation."""
+    points = np.array([[-0.5, 0.2], [0.5, 0.7], [1.5, 1.0]])
+    np.testing.assert_allclose(gaussian_kde.logpdf(points), gaussian_kde.scipy_kde.logpdf(points.T))
+
+
+def test_cdf(gaussian_kde: GaussianKDE):
+    """Test that cdf matches the underlying scipy implementation."""
+    points = np.array([[-0.5, 0.2], [0.5, 0.7], [1.5, 1.0]])
+    lower = np.full(gaussian_kde.dimension, -np.inf)
+    expected_cdf = np.array(
+        [
+            gaussian_kde.scipy_kde.integrate_box(low_bounds=lower, high_bounds=point)
+            for point in points
+        ]
+    )
+
+    np.testing.assert_allclose(gaussian_kde.cdf(points), expected_cdf)
+
+    point = np.array([-0.5, 0.2])
+    expected_single_point_cdf = gaussian_kde.scipy_kde.integrate_box(
+        low_bounds=lower, high_bounds=point
+    )
+    np.testing.assert_allclose(gaussian_kde.cdf(point), [expected_single_point_cdf])
+
+
+def test_evaluate_single_multivariate_point(gaussian_kde: GaussianKDE):
+    """Accept a single point without an explicit sample dimension."""
+    point_1d_array = np.array([-0.5, 0.2])
+    scipy_point = point_1d_array[:, np.newaxis]
+    np.testing.assert_allclose(
+        gaussian_kde.pdf(point_1d_array), gaussian_kde.scipy_kde.pdf(scipy_point)
+    )
+    np.testing.assert_allclose(
+        gaussian_kde.logpdf(point_1d_array), gaussian_kde.scipy_kde.logpdf(scipy_point)
+    )
+    assert gaussian_kde.cdf(point_1d_array).shape == (1,)
+
+
+@pytest.mark.parametrize("method_name", ["cdf", "pdf", "logpdf"])
+@pytest.mark.parametrize("points", [np.array([[1.0, 2.0, 3.0]]), np.array([1.0, 2.0, 3.0, 4.0])])
+def test_evaluate_rejects_wrong_point_shape(
+    gaussian_kde: GaussianKDE, method_name: str, points: np.ndarray
+):
+    """Reject points that do not match the distribution dimension."""
+    with pytest.raises(ValueError, match="Evaluation points must have shape"):
+        getattr(gaussian_kde, method_name)(points)
+
+
+def test_mean_and_covariance(gaussian_kde: GaussianKDE):
+    """Test that mean and covariance are calculated correctly."""
+    np.random.seed(42)
+    many_samples = gaussian_kde.draw(1_000_000)
+    np.testing.assert_allclose(gaussian_kde.mean, np.mean(many_samples, axis=0), rtol=1e-2)
+    np.testing.assert_allclose(
+        gaussian_kde.covariance, np.cov(many_samples, rowvar=False), rtol=1e-2
+    )
+
+
+def test_draw(gaussian_kde: GaussianKDE):
+    """Draw row-wise samples with the correct dimension."""
+    np.random.seed(42)
+    samples1 = gaussian_kde.draw(20)
+    assert samples1.shape == (20, 2)
+
+    # test reproducibility via np.random.seed
+    np.random.seed(42)
+    samples2 = gaussian_kde.draw(20)
+    np.testing.assert_allclose(samples1, samples2)
+
+
+def test_downsample_univariate():
+    """Test downsampling of univariate Gaussian KDE."""
+    # create a simple non-uniformly weighted bimodal distribution
+    random_generator = np.random.default_rng(42)
+    samples = np.concatenate(
+        [
+            random_generator.normal(-2.0, 0.7, 600),
+            random_generator.normal(2.0, 1.0, 400),
+        ]
+    )
+    weights = np.linspace(1.0, 2.0, samples.size)
+    weighted_bimodal_kde = GaussianKDE(samples, weights=weights)
+
+    # reduce to 10% of the original number of kernels
+    max_kernels = int(0.1 * weighted_bimodal_kde.samples.shape[0])
+    reduced_distribution = weighted_bimodal_kde.downsample(max_kernels=max_kernels, random_state=41)
+
+    # assert correct size after reduction
+    assert reduced_distribution.samples.shape == (max_kernels, 1)
+    assert reduced_distribution.weights.shape == (max_kernels,)
+
+    # assert mean is preserved almost exactly
+    np.testing.assert_allclose(reduced_distribution.mean, weighted_bimodal_kde.mean, rtol=1e-15)
+
+    # assert integrated error is small
+    grid = np.linspace(-5.0, 5.0, 101)
+    integrated_error = np.trapezoid(
+        np.abs(reduced_distribution.pdf(grid) - weighted_bimodal_kde.pdf(grid)), grid
+    )
+    assert integrated_error < 0.002
+
+
+def test_downsample_multivariate():
+    """Test downsampling of multivariate Gaussian KDE."""
+    # create a simple non-uniformly weighted bimodal distribution
+    random_generator = np.random.default_rng(42)
+    samples_x = np.concatenate(
+        [
+            random_generator.normal(-2.0, 0.7, 600),
+            random_generator.normal(2.0, 1.0, 400),
+        ]
+    )
+    samples_y = np.concatenate(
+        [
+            random_generator.normal(-1.0, 0.5, 600),
+            random_generator.normal(1.0, 0.8, 400),
+        ]
+    )
+
+    samples = np.column_stack((samples_x, samples_y))
+    weights = np.linspace(1.0, 2.0, samples.shape[0])
+    weighted_bimodal_kde = GaussianKDE(samples, weights=weights)
+
+    # reduce to 10% of the original number of kernels
+    max_kernels = int(0.1 * weighted_bimodal_kde.samples.shape[0])
+    reduced_distribution = weighted_bimodal_kde.downsample(max_kernels=max_kernels, random_state=41)
+
+    # assert correct size after reduction
+    assert reduced_distribution.samples.shape == (max_kernels, 2)
+    assert reduced_distribution.weights.shape == (max_kernels,)
+
+    # assert mean is preserved almost exactly
+    np.testing.assert_allclose(reduced_distribution.mean, weighted_bimodal_kde.mean, rtol=1e-14)
+
+    # assert integrated error is small
+    grid = np.linspace(-5.0, 5.0, 101)
+    x_grid, y_grid = np.meshgrid(grid, grid)
+    grid_points = np.column_stack((x_grid.ravel(), y_grid.ravel()))
+
+    # integrated_error
+    reduced_pdf_at_points = reduced_distribution.pdf(grid_points)
+    original_pdf_at_points = weighted_bimodal_kde.pdf(grid_points)
+    absolute_pdf_error = np.abs(reduced_pdf_at_points - original_pdf_at_points).reshape(
+        x_grid.shape
+    )
+    integrated_error = np.trapezoid(
+        np.trapezoid(absolute_pdf_error, x=grid, axis=0),
+        x=grid,
+    )
+
+    assert integrated_error < 0.04
+
+
+def test_downsample_small_kde_does_nothing(gaussian_kde: GaussianKDE):
+    """Avoid refitting a KDE that is already sufficiently small."""
+    assert gaussian_kde.downsample(max_kernels=4) is gaussian_kde
+
+
+@pytest.mark.parametrize("max_kernels", [-1, 2])
+def test_downsample_rejects_invalid_max_kernels(gaussian_kde: GaussianKDE, max_kernels):
+    """Require enough kernels for a nonsingular KDE."""
+    with pytest.raises(ValueError, match="larger than the distribution dimension"):
+        gaussian_kde.downsample(max_kernels=max_kernels)
+
+
+@pytest.mark.parametrize("samples", [[[1.0]], np.eye(2)])
+def test_init_rejects_too_few_kernels(samples):
+    """Require enough kernels to fit a nonsingular KDE."""
+    with pytest.raises(ValueError, match="larger than the distribution dimension"):
+        GaussianKDE(samples)
+
+
+def test_ppf(gaussian_kde: GaussianKDE):
+    """Reject inverse-CDF evaluation."""
+    with pytest.raises(
+        NotImplementedError, match="ppf not available for Gaussian KDE distributions."
+    ):
+        gaussian_kde.ppf(np.array([0.5]))
+
+
+def test_grad_logpdf(gaussian_kde: GaussianKDE):
+    """Reject log-PDF gradient evaluation."""
+    with pytest.raises(
+        NotImplementedError,
+        match="Gradient of logpdf not available for Gaussian KDE distributions.",
+    ):
+        gaussian_kde.grad_logpdf(np.array([[0.0, 0.0]]))


### PR DESCRIPTION
## Description and Context:<br> What and Why?
<!--
Provide a brief and concise description of your proposed change.
In particular: Why is this change required? What problem does it solve? Is this a breaking change?
-->

This adds a new `GaussianKDE` distribution that wraps `scipy.stats.gaussian_kde` to allow direct use in queens. For now, `ppf` and `grad_logpdf` remain unimplemented. 

I added tests for all functions, which mainly check directly against the underlying scipy object. The mean and covariance computation are tested against a simple Monte Carlo sampling of the distribution.

Additionally, I add a downsampling method that reduces the number of kernels in the Gaussian KDE to a user-specified value while preserving its shape. For that, `KMeans` is used to identify clusters in the distribution, which will serve as the new kernels for the downsampled KDE. This is tested for both the univariate and multivariate cases by downsampling a non-uniformly weighted bimodal distribution from 1000 kernels to 100 kernels and comparing the mean values and the integrated error.

The reasons to add this downsample method are that Gaussian KDEs can be quite expensive to evaluate with a large number of kernels, while (a lot) fewer kernels can still capture the distribution just as well.  

Finally, in the first commit I suggest changing the ruff pydocstyle config to not require docstrings on methods that override other methods, since those will have a docstring already. Consequently, the overridden methods of the `gaussianKDE` class are decorated with `@override` and don't have a docstring. This is not strictly part of this PR of course, but I thought it might be convenient in the future. But I am happy to drop this also :)


## Related Issues and Pull Requests
<!--
If applicable: how is this pull request related to other open issues or pull requests?
-->
* Closes
* Related to

## Interested Parties
<!--
If there's anyone you think should be looped in on this pull request,
feel free to @mention them here!
-->

> Note: More information on the merge request procedure in QUEENS can be found in the [*Submit a pull request*](../CONTRIBUTING.md#5-submit-a-pull-request) section in the [CONTRIBUTING.md](../CONTRIBUTING.md) file.
