### PR TITLE
Improve duplicate file error message in DataProcessor

### DIFF
--- a/src/queens/data_processors/_data_processor.py
+++ b/src/queens/data_processors/_data_processor.py
@@ -146,8 +146,8 @@ class DataProcessor(metaclass=abc.ABCMeta):
         if len(file_list) > 1:
             raise RuntimeError(
                 "The data_processor module found several files for the "
-                "provided 'file_name_prefix'!"
-                "The files are: {file_list}."
+                f"provided 'file_name_identifier' ({self.file_name_identifier!r})."
+                f"The files are: {file_list}."
                 "The file prefix must lead to a unique file. Abort..."
             )
         if len(file_list) == 1:


### PR DESCRIPTION
## Description and Context:<br> What and Why?
<!--
Provide a brief and concise description of your proposed change.
In particular: Why is this change required? What problem does it solve? Is this a breaking change?
-->

- fixes the error message for duplicate files in the `DataProcessor` class
- updates the outdated term of `file_name_prefix` to `file_name_identifier` in error message

## Related Issues and Pull Requests
<!--
If applicable: how is this pull request related to other open issues or pull requests?
-->
* Closes
* Related to

## Interested Parties
<!--
If there's anyone you think should be looped in on this pull request,
feel free to @mention them here!
-->

> Note: More information on the merge request procedure in QUEENS can be found in the [*Submit a pull request*](../CONTRIBUTING.md#5-submit-a-pull-request) section in the [CONTRIBUTING.md](../CONTRIBUTING.md) file.
