### PR TITLE
style: Make override decorator usage mandatory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,6 +170,7 @@ disallow_untyped_decorators = true
 disallow_untyped_defs = true
 ignore_missing_imports = true
 disable_error_code = ["str-bytes-safe"]
+enable_error_code = ["explicit-override"]
 # Delete modules once type hinting has been introduced there
 exclude = '''(?x)(
     ^(.gitlab|.github|config|doc|tests|test_utils)/|

--- a/src/queens/distributions/_distribution.py
+++ b/src/queens/distributions/_distribution.py
@@ -151,7 +151,7 @@ class Continuous(Distribution):
     @override
     def pdf(self, x: np.ndarray) -> np.ndarray:
         logpdf = self.logpdf(x)
-        pdf = np.exp(logpdf) if logpdf is not None else None
+        pdf = np.exp(logpdf)
         return pdf
 
     @abstractmethod

--- a/src/queens/distributions/_distribution.py
+++ b/src/queens/distributions/_distribution.py
@@ -37,16 +37,20 @@ class Distribution(abc.ABC):
 
         Args:
             num_draws: Number of draws
+
+        Returns:
+            Drawn samples from the distribution
         """
 
     @abstractmethod
     def logpdf(self, x: np.ndarray) -> np.ndarray:
-        """Log of the probability *mass* function.
-
-        In order to keep the interfaces unified the PMF is also accessed via the PDF.
+        """Log of the probability density function.
 
         Args:
             x: Positions at which the log-PDF is evaluated
+
+        Returns:
+            log-PDF at positions
         """
 
     @abstractmethod
@@ -55,6 +59,9 @@ class Distribution(abc.ABC):
 
         Args:
             x: Positions at which the PDF is evaluated
+
+        Returns:
+            PDF at positions
         """
 
     def export_dict(self) -> dict:
@@ -117,6 +124,9 @@ class Continuous(Distribution):
 
         Args:
             x: Positions at which the CDF is evaluated
+
+        Returns:
+            CDF at positions
         """
 
     @override
@@ -125,12 +135,7 @@ class Continuous(Distribution):
 
     @override
     @abstractmethod
-    def logpdf(self, x: np.ndarray) -> np.ndarray:
-        """Log of the probability density function.
-
-        Args:
-            x: Positions at which the log-PDF is evaluated
-        """
+    def logpdf(self, x: np.ndarray) -> np.ndarray: ...
 
     @abstractmethod
     def grad_logpdf(self, x: np.ndarray) -> np.ndarray:
@@ -138,18 +143,13 @@ class Continuous(Distribution):
 
         Args:
             x: Positions at which the gradient of log-PDF is evaluated
+
+        Returns:
+            Gradient of the log-PDF evaluated at positions
         """
 
     @override
     def pdf(self, x: np.ndarray) -> np.ndarray:
-        """Probability density function.
-
-        Args:
-            x: Positions at which the PDF is evaluated
-
-        Returns:
-            PDF at positions
-        """
         logpdf = self.logpdf(x)
         pdf = np.exp(logpdf) if logpdf is not None else None
         return pdf
@@ -160,6 +160,9 @@ class Continuous(Distribution):
 
         Args:
             quantiles: Quantiles at which the PPF is evaluated
+
+        Returns:
+            Positions which correspond to given quantiles
         """
 
     def check_1d(self) -> None:
@@ -259,7 +262,14 @@ class Discrete(Distribution):
 
     @override
     @abstractmethod
-    def pdf(self, x: np.ndarray) -> np.ndarray: ...
+    def pdf(self, x: np.ndarray) -> np.ndarray:
+        """Log of the probability *mass* function.
+
+        In order to keep the interfaces unified, the PMF is also accessed via the PDF.
+
+        Args:
+            x: Positions at which the log-PDF is evaluated
+        """
 
     @abstractmethod
     def cdf(self, x: np.ndarray) -> np.ndarray | None:
@@ -282,8 +292,8 @@ class Discrete(Distribution):
         """Compute the mean value and covariance of the distribution.
 
         Returns:
-            Mean value of the distribution
-            Covariance of the distribution
+            mean: Mean value of the distribution
+            covariance: Covariance of the distribution
         """
 
     def check_1d(self) -> None:

--- a/src/queens/distributions/_distribution.py
+++ b/src/queens/distributions/_distribution.py
@@ -263,7 +263,7 @@ class Discrete(Distribution):
     @override
     @abstractmethod
     def pdf(self, x: np.ndarray) -> np.ndarray:
-        """Log of the probability *mass* function.
+        """Probability *mass* function.
 
         In order to keep the interfaces unified, the PMF is also accessed via the PDF.
 

--- a/src/queens/distributions/_distribution.py
+++ b/src/queens/distributions/_distribution.py
@@ -121,12 +121,7 @@ class Continuous(Distribution):
 
     @override
     @abstractmethod
-    def draw(self, num_draws: int = 1) -> np.ndarray:
-        """Draw samples.
-
-        Args:
-            num_draws: Number of draws
-        """
+    def draw(self, num_draws: int = 1) -> np.ndarray: ...
 
     @override
     @abstractmethod
@@ -249,12 +244,7 @@ class Discrete(Distribution):
 
     @override
     @abstractmethod
-    def draw(self, num_draws: int = 1) -> np.ndarray:
-        """Draw samples.
-
-        Args:
-            num_draws: Number of draws
-        """
+    def draw(self, num_draws: int = 1) -> np.ndarray: ...
 
     @override
     @abstractmethod
@@ -269,12 +259,7 @@ class Discrete(Distribution):
 
     @override
     @abstractmethod
-    def pdf(self, x: np.ndarray) -> np.ndarray:
-        """Probability density function.
-
-        Args:
-            x: Positions at which the PDF is evaluated
-        """
+    def pdf(self, x: np.ndarray) -> np.ndarray: ...
 
     @abstractmethod
     def cdf(self, x: np.ndarray) -> np.ndarray | None:

--- a/src/queens/distributions/_distribution.py
+++ b/src/queens/distributions/_distribution.py
@@ -18,6 +18,7 @@ import abc
 import logging
 from abc import abstractmethod
 from collections.abc import Sequence, Sized
+from typing import override
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -66,6 +67,7 @@ class Distribution(abc.ABC):
         export_dict = {"type": self.__class__.__name__, **export_dict}
         return export_dict
 
+    @override
     def __str__(self) -> str:
         """Get string for the given distribution.
 
@@ -117,6 +119,7 @@ class Continuous(Distribution):
             x: Positions at which the CDF is evaluated
         """
 
+    @override
     @abstractmethod
     def draw(self, num_draws: int = 1) -> np.ndarray:
         """Draw samples.
@@ -125,6 +128,7 @@ class Continuous(Distribution):
             num_draws: Number of draws
         """
 
+    @override
     @abstractmethod
     def logpdf(self, x: np.ndarray) -> np.ndarray:
         """Log of the probability density function.
@@ -141,6 +145,7 @@ class Continuous(Distribution):
             x: Positions at which the gradient of log-PDF is evaluated
         """
 
+    @override
     def pdf(self, x: np.ndarray) -> np.ndarray:
         """Probability density function.
 
@@ -242,6 +247,7 @@ class Discrete(Distribution):
 
         self.mean, self.covariance = self._compute_mean_and_covariance()
 
+    @override
     @abstractmethod
     def draw(self, num_draws: int = 1) -> np.ndarray:
         """Draw samples.
@@ -250,6 +256,7 @@ class Discrete(Distribution):
             num_draws: Number of draws
         """
 
+    @override
     @abstractmethod
     def logpdf(self, x: np.ndarray) -> np.ndarray:
         """Log of the probability *mass* function.
@@ -260,6 +267,7 @@ class Discrete(Distribution):
             x: Positions at which the log-PDF is evaluated
         """
 
+    @override
     @abstractmethod
     def pdf(self, x: np.ndarray) -> np.ndarray:
         """Probability density function.

--- a/src/queens/distributions/beta.py
+++ b/src/queens/distributions/beta.py
@@ -119,14 +119,6 @@ class Beta(Continuous):
 
     @override
     def pdf(self, x: np.ndarray) -> np.ndarray:
-        """Probability density function.
-
-        Args:
-            x: Positions at which the PDF is evaluated
-
-        Returns:
-            PDF at positions
-        """
         pdf = self.scipy_beta.pdf(x).reshape(-1)
         return pdf
 

--- a/src/queens/distributions/beta.py
+++ b/src/queens/distributions/beta.py
@@ -69,50 +69,21 @@ class Beta(Continuous):
 
     @override
     def cdf(self, x: np.ndarray) -> np.ndarray:
-        """Cumulative distribution function.
-
-        Args:
-            x: Positions at which the CDF is evaluated
-
-        Returns:
-            CDF at positions
-        """
         cdf = self.scipy_beta.cdf(x).reshape(-1)
         return cdf
 
     @override
     def draw(self, num_draws: int = 1) -> np.ndarray:
-        """Draw samples.
-
-        Args:
-            num_draws: Number of draws
-
-        Returns:
-            Drawn samples from the distribution
-        """
         samples = self.scipy_beta.rvs(size=num_draws).reshape(-1, 1)
         return samples
 
     @override
     def logpdf(self, x: np.ndarray) -> np.ndarray:
-        """Log of the probability density function.
-
-        Args:
-            x: Positions at which the log-PDF is evaluated
-
-        Returns:
-            Log-PDF at positions
-        """
         logpdf = self.scipy_beta.logpdf(x).reshape(-1)
         return logpdf
 
     @override
     def grad_logpdf(self, x: np.ndarray) -> np.ndarray:
-        """Gradient of the log-PDF with respect to *x*.
-
-        Args:
-            x: Positions at which the gradient of the log-PDF is evaluated
-        """
         raise NotImplementedError(
             "This method is currently not implemented for the beta distribution."
         )
@@ -124,13 +95,5 @@ class Beta(Continuous):
 
     @override
     def ppf(self, quantiles: np.ndarray) -> np.ndarray:
-        """Percent point function (inverse of CDF — quantiles).
-
-        Args:
-            quantiles: Quantiles at which the PPF is evaluated
-
-        Returns:
-            Positions which correspond to given quantiles
-        """
         ppf = self.scipy_beta.ppf(quantiles).reshape(-1)
         return ppf

--- a/src/queens/distributions/beta.py
+++ b/src/queens/distributions/beta.py
@@ -14,6 +14,8 @@
 #
 """Beta Distribution."""
 
+from typing import override
+
 import numpy as np
 import scipy.stats
 
@@ -65,6 +67,7 @@ class Beta(Continuous):
 
         super().__init__(mean=mean, covariance=covariance, dimension=1)
 
+    @override
     def cdf(self, x: np.ndarray) -> np.ndarray:
         """Cumulative distribution function.
 
@@ -77,6 +80,7 @@ class Beta(Continuous):
         cdf = self.scipy_beta.cdf(x).reshape(-1)
         return cdf
 
+    @override
     def draw(self, num_draws: int = 1) -> np.ndarray:
         """Draw samples.
 
@@ -89,6 +93,7 @@ class Beta(Continuous):
         samples = self.scipy_beta.rvs(size=num_draws).reshape(-1, 1)
         return samples
 
+    @override
     def logpdf(self, x: np.ndarray) -> np.ndarray:
         """Log of the probability density function.
 
@@ -101,6 +106,7 @@ class Beta(Continuous):
         logpdf = self.scipy_beta.logpdf(x).reshape(-1)
         return logpdf
 
+    @override
     def grad_logpdf(self, x: np.ndarray) -> np.ndarray:
         """Gradient of the log-PDF with respect to *x*.
 
@@ -111,6 +117,7 @@ class Beta(Continuous):
             "This method is currently not implemented for the beta distribution."
         )
 
+    @override
     def pdf(self, x: np.ndarray) -> np.ndarray:
         """Probability density function.
 
@@ -123,6 +130,7 @@ class Beta(Continuous):
         pdf = self.scipy_beta.pdf(x).reshape(-1)
         return pdf
 
+    @override
     def ppf(self, quantiles: np.ndarray) -> np.ndarray:
         """Percent point function (inverse of CDF — quantiles).
 

--- a/src/queens/distributions/categorical.py
+++ b/src/queens/distributions/categorical.py
@@ -66,14 +66,6 @@ class Categorical(Distribution):
 
     @override
     def draw(self, num_draws: int = 1) -> np.ndarray:
-        """Draw samples.
-
-        Args:
-            num_draws: Number of draws
-
-        Returns:
-            Samples of the categorical distribution
-        """
         samples_per_category = np.random.multinomial(num_draws, self.probabilities)
         samples_tuple = (
             [
@@ -93,6 +85,8 @@ class Categorical(Distribution):
     def logpdf(self, x: np.ndarray) -> np.ndarray:
         """Log of the probability *mass* function.
 
+        In order to keep the interfaces unified the log-PMF is also accessed via the log-PDF.
+
         Args:
             x: Positions at which the log-PMF is evaluated
 
@@ -104,6 +98,8 @@ class Categorical(Distribution):
     @override
     def pdf(self, x: np.ndarray) -> np.ndarray:
         """Probability *mass* function.
+
+        In order to keep the interfaces unified the PMF is also accessed via the PDF.
 
         Args:
             x: Positions at which the PMF is evaluated

--- a/src/queens/distributions/categorical.py
+++ b/src/queens/distributions/categorical.py
@@ -14,11 +14,13 @@
 #
 """General categorical distribution.
 
-Disclaimer: Most of our iterators are not able to handle categorical distributions.
+Disclaimer: Most of our iterators are not able to handle categorical
+distributions.
 """
 
 import itertools
 import logging
+from typing import override
 
 import numpy as np
 
@@ -62,6 +64,7 @@ class Categorical(Distribution):
         self.probabilities = probabilities
         self.categories = categories
 
+    @override
     def draw(self, num_draws: int = 1) -> np.ndarray:
         """Draw samples.
 
@@ -86,6 +89,7 @@ class Categorical(Distribution):
         np.random.shuffle(samples)
         return samples.reshape(-1, 1)
 
+    @override
     def logpdf(self, x: np.ndarray) -> np.ndarray:
         """Log of the probability *mass* function.
 
@@ -97,6 +101,7 @@ class Categorical(Distribution):
         """
         return np.log(self.pdf(x))
 
+    @override
     def pdf(self, x: np.ndarray) -> np.ndarray:
         """Probability *mass* function.
 

--- a/src/queens/distributions/exponential.py
+++ b/src/queens/distributions/exponential.py
@@ -61,14 +61,6 @@ class Exponential(Continuous):
 
     @override
     def cdf(self, x: np.ndarray) -> np.ndarray:
-        """Cumulative distribution function.
-
-        Args:
-            x: Positions at which the CDF is evaluated
-
-        Returns:
-            CDF at positions
-        """
         x = x.reshape(-1, self.dimension)
         condition = (x >= 0).all(axis=1)
         cdf = np.where(condition, np.prod(1 - np.exp(-self.rate * x), axis=1), 0)
@@ -76,27 +68,11 @@ class Exponential(Continuous):
 
     @override
     def draw(self, num_draws: int = 1) -> np.ndarray:
-        """Draw samples.
-
-        Args:
-            num_draws: Number of draws
-
-        Returns:
-            Drawn samples from the distribution
-        """
         samples = np.random.exponential(scale=self.scale, size=(num_draws, self.dimension))
         return samples
 
     @override
     def logpdf(self, x: np.ndarray) -> np.ndarray:
-        """Log of the probability density function.
-
-        Args:
-            x: Positions at which the log-PDF is evaluated
-
-        Returns:
-            Log-PDF at positions
-        """
         x = x.reshape(-1, self.dimension)
         condition = (x >= 0).all(axis=1)
         logpdf = self.logpdf_const + np.where(condition, np.sum(-self.rate * x, axis=1), -np.inf)
@@ -104,14 +80,6 @@ class Exponential(Continuous):
 
     @override
     def grad_logpdf(self, x: np.ndarray) -> np.ndarray:
-        """Gradient of the log-PDF with respect to *x*.
-
-        Args:
-            x: Positions at which the gradient of the log-PDF is evaluated
-
-        Returns:
-            Gradient of the log-PDF evaluated at positions
-        """
         x = x.reshape(-1, self.dimension)
         condition = (x >= 0).all(axis=1).reshape(-1, 1)
         grad_logpdf = np.where(condition, -self.rate, np.nan)
@@ -119,14 +87,6 @@ class Exponential(Continuous):
 
     @override
     def ppf(self, quantiles: np.ndarray) -> np.ndarray:
-        """Percent point function (inverse of CDF — quantiles).
-
-        Args:
-            quantiles: Quantiles at which the PPF is evaluated
-
-        Returns:
-            Positions which correspond to given quantiles
-        """
         self.check_1d()
         ppf = -self.scale * np.log(1 - quantiles)
         return ppf

--- a/src/queens/distributions/exponential.py
+++ b/src/queens/distributions/exponential.py
@@ -14,6 +14,8 @@
 #
 """Exponential distribution."""
 
+from typing import override
+
 import numpy as np
 
 from queens.distributions._distribution import Continuous
@@ -57,6 +59,7 @@ class Exponential(Continuous):
         self.pdf_const = pdf_const
         self.logpdf_const = logpdf_const
 
+    @override
     def cdf(self, x: np.ndarray) -> np.ndarray:
         """Cumulative distribution function.
 
@@ -71,6 +74,7 @@ class Exponential(Continuous):
         cdf = np.where(condition, np.prod(1 - np.exp(-self.rate * x), axis=1), 0)
         return cdf
 
+    @override
     def draw(self, num_draws: int = 1) -> np.ndarray:
         """Draw samples.
 
@@ -83,6 +87,7 @@ class Exponential(Continuous):
         samples = np.random.exponential(scale=self.scale, size=(num_draws, self.dimension))
         return samples
 
+    @override
     def logpdf(self, x: np.ndarray) -> np.ndarray:
         """Log of the probability density function.
 
@@ -97,6 +102,7 @@ class Exponential(Continuous):
         logpdf = self.logpdf_const + np.where(condition, np.sum(-self.rate * x, axis=1), -np.inf)
         return logpdf
 
+    @override
     def grad_logpdf(self, x: np.ndarray) -> np.ndarray:
         """Gradient of the log-PDF with respect to *x*.
 
@@ -111,6 +117,7 @@ class Exponential(Continuous):
         grad_logpdf = np.where(condition, -self.rate, np.nan)
         return grad_logpdf
 
+    @override
     def ppf(self, quantiles: np.ndarray) -> np.ndarray:
         """Percent point function (inverse of CDF — quantiles).
 

--- a/src/queens/distributions/free_variable.py
+++ b/src/queens/distributions/free_variable.py
@@ -14,7 +14,7 @@
 #
 """Free Variable."""
 
-from typing import Any
+from typing import Any, override
 
 import numpy as np
 
@@ -38,26 +38,32 @@ class FreeVariable(Continuous):
         """
         super().__init__(mean=np.array([]), covariance=np.array([]), dimension=dimension)
 
+    @override
     def cdf(self, _: Any) -> np.ndarray:
         """Cumulative distribution function."""
         raise ValueError("cdf method is not supported for FreeVariable.")
 
+    @override
     def draw(self, _: int = 1) -> np.ndarray:
         """Draw samples."""
         raise ValueError("draw method is not supported for FreeVariable.")
 
+    @override
     def logpdf(self, _: Any) -> np.ndarray:
         """Log of the probability density function."""
         raise ValueError("logpdf method is not supported for FreeVariable.")
 
+    @override
     def grad_logpdf(self, _: Any) -> np.ndarray:
         """Gradient of the log-PDF with respect to *x*."""
         raise ValueError("grad_logpdf method is not supported for FreeVariable.")
 
+    @override
     def pdf(self, _: Any) -> np.ndarray:
         """Probability density function."""
         raise ValueError("pdf method is not supported for FreeVariable.")
 
+    @override
     def ppf(self, _: Any) -> np.ndarray:
         """Percent point function (inverse of CDF — quantiles)."""
         raise ValueError("ppf method is not supported for FreeVariable.")

--- a/src/queens/distributions/free_variable.py
+++ b/src/queens/distributions/free_variable.py
@@ -40,30 +40,24 @@ class FreeVariable(Continuous):
 
     @override
     def cdf(self, _: Any) -> np.ndarray:
-        """Cumulative distribution function."""
         raise ValueError("cdf method is not supported for FreeVariable.")
 
     @override
     def draw(self, _: int = 1) -> np.ndarray:
-        """Draw samples."""
         raise ValueError("draw method is not supported for FreeVariable.")
 
     @override
     def logpdf(self, _: Any) -> np.ndarray:
-        """Log of the probability density function."""
         raise ValueError("logpdf method is not supported for FreeVariable.")
 
     @override
     def grad_logpdf(self, _: Any) -> np.ndarray:
-        """Gradient of the log-PDF with respect to *x*."""
         raise ValueError("grad_logpdf method is not supported for FreeVariable.")
 
     @override
     def pdf(self, _: Any) -> np.ndarray:
-        """Probability density function."""
         raise ValueError("pdf method is not supported for FreeVariable.")
 
     @override
     def ppf(self, _: Any) -> np.ndarray:
-        """Percent point function (inverse of CDF — quantiles)."""
         raise ValueError("ppf method is not supported for FreeVariable.")

--- a/src/queens/distributions/lognormal.py
+++ b/src/queens/distributions/lognormal.py
@@ -135,14 +135,6 @@ class LogNormal(Continuous):
 
     @override
     def pdf(self, x: np.ndarray) -> np.ndarray:
-        """Probability density function.
-
-        Args:
-            x: Positions at which the PDF is evaluated
-
-        Returns:
-            PDF at positions
-        """
         return np.exp(self.logpdf(x))
 
     @override

--- a/src/queens/distributions/lognormal.py
+++ b/src/queens/distributions/lognormal.py
@@ -60,14 +60,6 @@ class LogNormal(Continuous):
 
     @override
     def cdf(self, x: np.ndarray) -> np.ndarray:
-        """Cumulative distribution function.
-
-        Args:
-            x: Positions at which the CDF is evaluated
-
-        Returns:
-            CDF at positions
-        """
         x = np.asarray(x, dtype=float).reshape(-1, self.dimension)
         cdf = np.zeros(x.shape[0])
         positive_support = np.all(x > 0, axis=1)
@@ -79,26 +71,10 @@ class LogNormal(Continuous):
 
     @override
     def draw(self, num_draws: int = 1) -> np.ndarray:
-        """Draw samples.
-
-        Args:
-            num_draws: Number of draws
-
-        Returns:
-            Drawn samples from the distribution
-        """
         return np.exp(self.normal_distribution.draw(num_draws=num_draws))
 
     @override
     def logpdf(self, x: ArrayLike) -> np.ndarray:
-        """Log of the probability density function.
-
-        Args:
-            x: Positions at which the log-PDF is evaluated
-
-        Returns:
-            Log-PDF at positions
-        """
         log_x = np.log(x).reshape(-1, self.dimension)
         dist = log_x - self.normal_distribution.mean
         logpdf = (
@@ -110,14 +86,6 @@ class LogNormal(Continuous):
 
     @override
     def grad_logpdf(self, x: np.ndarray) -> np.ndarray:
-        """Gradient of the log-PDF with respect to *x*.
-
-        Args:
-            x: Positions at which the gradient of log-PDF is evaluated
-
-        Returns:
-            Gradient of the log-PDF evaluated at positions
-        """
         x = x.reshape(-1, self.dimension)
         x[x == 0] = np.nan
         grad_logpdf = (
@@ -139,14 +107,6 @@ class LogNormal(Continuous):
 
     @override
     def ppf(self, quantiles: ArrayLike) -> np.ndarray:
-        """Percent point function (inverse of CDF — quantiles).
-
-        Args:
-            quantiles: Quantiles at which the PPF is evaluated
-
-        Returns:
-            Positions which correspond to given quantiles
-        """
         self.check_1d()
         ppf = scipy.stats.lognorm.ppf(
             quantiles,

--- a/src/queens/distributions/lognormal.py
+++ b/src/queens/distributions/lognormal.py
@@ -14,6 +14,8 @@
 #
 """LogNormal Distribution."""
 
+from typing import override
+
 import numpy as np
 import scipy.linalg
 import scipy.stats
@@ -56,6 +58,7 @@ class LogNormal(Continuous):
             mean=mean, covariance=covariance, dimension=self.normal_distribution.dimension
         )
 
+    @override
     def cdf(self, x: np.ndarray) -> np.ndarray:
         """Cumulative distribution function.
 
@@ -74,6 +77,7 @@ class LogNormal(Continuous):
 
         return cdf
 
+    @override
     def draw(self, num_draws: int = 1) -> np.ndarray:
         """Draw samples.
 
@@ -85,6 +89,7 @@ class LogNormal(Continuous):
         """
         return np.exp(self.normal_distribution.draw(num_draws=num_draws))
 
+    @override
     def logpdf(self, x: ArrayLike) -> np.ndarray:
         """Log of the probability density function.
 
@@ -103,6 +108,7 @@ class LogNormal(Continuous):
         )
         return logpdf
 
+    @override
     def grad_logpdf(self, x: np.ndarray) -> np.ndarray:
         """Gradient of the log-PDF with respect to *x*.
 
@@ -127,6 +133,7 @@ class LogNormal(Continuous):
         )
         return grad_logpdf
 
+    @override
     def pdf(self, x: np.ndarray) -> np.ndarray:
         """Probability density function.
 
@@ -138,6 +145,7 @@ class LogNormal(Continuous):
         """
         return np.exp(self.logpdf(x))
 
+    @override
     def ppf(self, quantiles: ArrayLike) -> np.ndarray:
         """Percent point function (inverse of CDF — quantiles).
 

--- a/src/queens/distributions/mean_field_normal.py
+++ b/src/queens/distributions/mean_field_normal.py
@@ -14,6 +14,8 @@
 #
 """Mean-field normal distribution."""
 
+from typing import override
+
 import numpy as np
 import scipy.stats
 from numpy.typing import ArrayLike
@@ -67,6 +69,7 @@ class MeanFieldNormal(Continuous):
         mean = MeanFieldNormal.get_check_array_dimension_and_reshape(mean, self.dimension)
         self.mean = mean
 
+    @override
     def cdf(self, x: np.ndarray) -> np.ndarray:
         """Cumulative distribution function.
 
@@ -81,6 +84,7 @@ class MeanFieldNormal(Continuous):
         cdf = np.prod(cdf, axis=1).reshape(x.shape[0], -1)
         return cdf
 
+    @override
     def draw(self, num_draws: int = 1) -> np.ndarray:
         """Draw samples.
 
@@ -96,6 +100,7 @@ class MeanFieldNormal(Continuous):
 
         return samples
 
+    @override
     def logpdf(self, x: np.ndarray) -> np.ndarray:
         """Log of the probability density function.
 
@@ -114,6 +119,7 @@ class MeanFieldNormal(Continuous):
 
         return logpdf
 
+    @override
     def grad_logpdf(self, x: np.ndarray) -> np.ndarray:
         """Gradient of the log-PDF with respect to x.
 
@@ -147,6 +153,7 @@ class MeanFieldNormal(Continuous):
 
         return grad_logpdf_var
 
+    @override
     def ppf(self, quantiles: np.ndarray) -> np.ndarray:
         """Percent point function (inverse of cdf — quantiles).
 

--- a/src/queens/distributions/mean_field_normal.py
+++ b/src/queens/distributions/mean_field_normal.py
@@ -71,14 +71,6 @@ class MeanFieldNormal(Continuous):
 
     @override
     def cdf(self, x: np.ndarray) -> np.ndarray:
-        """Cumulative distribution function.
-
-        Args:
-            x: Positions at which the CDF is evaluated
-
-        Returns:
-            CDF at positions
-        """
         z = (x - self.mean) / self.standard_deviation
         cdf = 0.5 * (1 + erf(z / np.sqrt(2)))
         cdf = np.prod(cdf, axis=1).reshape(x.shape[0], -1)
@@ -86,14 +78,6 @@ class MeanFieldNormal(Continuous):
 
     @override
     def draw(self, num_draws: int = 1) -> np.ndarray:
-        """Draw samples.
-
-        Args:
-            num_draws: Number of draws
-
-        Returns:
-            Drawn samples from the distribution
-        """
         samples = np.random.randn(num_draws, self.dimension) * self.standard_deviation.reshape(
             1, -1
         ) + self.mean.reshape(1, -1)
@@ -102,14 +86,6 @@ class MeanFieldNormal(Continuous):
 
     @override
     def logpdf(self, x: np.ndarray) -> np.ndarray:
-        """Log of the probability density function.
-
-        Args:
-            x: Positions at which the log-PDF is evaluated
-
-        Returns:
-            Log-PDF at positions
-        """
         dist = x - self.mean
         logpdf = (
             -0.5 * self.dimension * np.log(2 * np.pi)
@@ -121,14 +97,6 @@ class MeanFieldNormal(Continuous):
 
     @override
     def grad_logpdf(self, x: np.ndarray) -> np.ndarray:
-        """Gradient of the log-PDF with respect to x.
-
-        Args:
-            x: Positions at which the gradient of log-PDF is evaluated
-
-        Returns:
-            Gradient of the log-PDF evaluated at positions
-        """
         gradients_batch = -(x - self.mean) / self.covariance
         gradients_batch = gradients_batch.reshape(x.shape[0], -1)
 
@@ -155,11 +123,6 @@ class MeanFieldNormal(Continuous):
 
     @override
     def ppf(self, quantiles: np.ndarray) -> np.ndarray:
-        """Percent point function (inverse of cdf — quantiles).
-
-        Args:
-            quantiles: Quantiles at which the PPF is evaluated
-        """
         self.check_1d()  # pylint: disable=duplicate-code
         ppf = scipy.stats.norm.ppf(
             quantiles, loc=self.mean, scale=self.covariance ** (1 / 2)

--- a/src/queens/distributions/mixture.py
+++ b/src/queens/distributions/mixture.py
@@ -15,7 +15,7 @@
 """Mixture distribution."""
 
 import logging
-from typing import Sequence
+from typing import Sequence, override
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -84,6 +84,7 @@ class Mixture(Continuous):
         covariance -= np.outer(mean, mean)
         return mean, covariance
 
+    @override
     def draw(self, num_draws: int = 1) -> np.ndarray:
         """Draw *num_draw* samples from the variational distribution.
 
@@ -116,6 +117,7 @@ class Mixture(Continuous):
 
         return samples
 
+    @override
     def cdf(self, x: np.ndarray) -> np.ndarray:
         """Cumulative distribution function.
 
@@ -132,6 +134,7 @@ class Mixture(Continuous):
             cdf += weights * component.cdf(x)
         return cdf
 
+    @override
     def logpdf(self, x: np.ndarray) -> np.ndarray:
         """Log of the probability density function.
 
@@ -150,6 +153,7 @@ class Mixture(Continuous):
 
         return logpdf
 
+    @override
     def pdf(self, x: np.ndarray) -> np.ndarray:
         """Probability density function.
 
@@ -161,6 +165,7 @@ class Mixture(Continuous):
         """
         return np.exp(self.logpdf(x))
 
+    @override
     def grad_logpdf(self, x: np.ndarray) -> np.ndarray:
         """Gradient of the log-PDF with respect to *x*.
 
@@ -180,6 +185,7 @@ class Mixture(Continuous):
 
         return np.array(grad_logpdf).reshape(len(x), -1)
 
+    @override
     def ppf(self, quantiles: np.ndarray) -> np.ndarray:
         """Percent point function (inverse of CDF — quantiles).
 
@@ -222,6 +228,7 @@ class Mixture(Continuous):
         )
         return np.exp(inv_log_responsibility).T
 
+    @override
     def export_dict(self) -> dict:
         """Create a dict of the distribution.
 

--- a/src/queens/distributions/mixture.py
+++ b/src/queens/distributions/mixture.py
@@ -155,14 +155,6 @@ class Mixture(Continuous):
 
     @override
     def pdf(self, x: np.ndarray) -> np.ndarray:
-        """Probability density function.
-
-        Args:
-            x: Positions at which the PDF is evaluated
-
-        Returns:
-            PDF at positions
-        """
         return np.exp(self.logpdf(x))
 
     @override
@@ -187,11 +179,6 @@ class Mixture(Continuous):
 
     @override
     def ppf(self, quantiles: np.ndarray) -> np.ndarray:
-        """Percent point function (inverse of CDF — quantiles).
-
-        Args:
-            quantiles: Quantiles at which the PPF is evaluated
-        """
         raise NotImplementedError("PPF not available for mixture models.")
 
     def responsibilities(self, x: np.ndarray) -> np.ndarray:

--- a/src/queens/distributions/mixture.py
+++ b/src/queens/distributions/mixture.py
@@ -119,14 +119,6 @@ class Mixture(Continuous):
 
     @override
     def cdf(self, x: np.ndarray) -> np.ndarray:
-        """Cumulative distribution function.
-
-        Args:
-            x: Positions at which the CDF is evaluated
-
-        Returns:
-            CDF of the mixture model
-        """
         cdf = np.zeros(
             x.reshape(-1, self.component_distributions[0].dimension).shape[0], dtype=float
         )
@@ -136,14 +128,6 @@ class Mixture(Continuous):
 
     @override
     def logpdf(self, x: np.ndarray) -> np.ndarray:
-        """Log of the probability density function.
-
-        Args:
-            x: Positions at which the log-PDF is evaluated
-
-        Returns:
-            Log-PDF at positions
-        """
         log_weights = np.log(self.weights)
         weighted_logpdf = []
         for log_weight, component in zip(log_weights, self.component_distributions, strict=True):
@@ -159,14 +143,6 @@ class Mixture(Continuous):
 
     @override
     def grad_logpdf(self, x: np.ndarray) -> np.ndarray:
-        """Gradient of the log-PDF with respect to *x*.
-
-        Args:
-            x: Positions at which the gradient of log-PDF is evaluated
-
-        Returns:
-            Gradient of the log-PDF evaluated at positions
-        """
         responsibilities = self.responsibilities(x)
 
         grad_logpdf = 0
@@ -217,11 +193,6 @@ class Mixture(Continuous):
 
     @override
     def export_dict(self) -> dict:
-        """Create a dict of the distribution.
-
-        Returns:
-            Dictionary containing distribution information
-        """
         dictionary = super().export_dict()
         dictionary.pop("component_distributions")
         for i, components in enumerate(self.component_distributions):

--- a/src/queens/distributions/multinomial.py
+++ b/src/queens/distributions/multinomial.py
@@ -49,12 +49,6 @@ class Multinomial(Discrete):
 
     @override
     def _compute_mean_and_covariance(self) -> tuple[np.ndarray, np.ndarray]:
-        """Compute the mean value and covariance of the mixture model.
-
-        Returns:
-            Mean value of the distribution
-            Covariance of the distribution
-        """
         n_trials = self.sample_space[0]
         mean = n_trials * self.probabilities
         covariance = n_trials * (
@@ -64,38 +58,14 @@ class Multinomial(Discrete):
 
     @override
     def draw(self, num_draws: int = 1) -> np.ndarray:
-        """Draw samples.
-
-        Args:
-            num_draws: Number of draws
-
-        Returns:
-            Drawn samples
-        """
         return np.random.multinomial(self.n_trials, self.probabilities, size=num_draws)
 
     @override
     def logpdf(self, x: np.ndarray) -> np.ndarray:
-        """Log of the probability mass function.
-
-        Args:
-            x: Positions at which the log-PMF is evaluated
-
-        Returns:
-            Log-PMF at positions
-        """
         return self.scipy_multinomial.logpmf(x)
 
     @override
     def pdf(self, x: np.ndarray) -> np.ndarray:
-        """Probability mass function.
-
-        Args:
-            x: Positions at which the PMF is evaluated
-
-        Returns:
-            PMF at positions
-        """
         return self.scipy_multinomial.pmf(x)
 
     @override

--- a/src/queens/distributions/multinomial.py
+++ b/src/queens/distributions/multinomial.py
@@ -100,18 +100,8 @@ class Multinomial(Discrete):
 
     @override
     def cdf(self, x: np.ndarray) -> None:
-        """Cumulative distribution function.
-
-        Args:
-            x: Positions at which the CDF is evaluated
-        """
         super().check_1d()
 
     @override
     def ppf(self, quantiles: np.ndarray) -> None:
-        """Percent point function (inverse of CDF - quantiles).
-
-        Args:
-            quantiles: Quantiles at which the PPF is evaluated
-        """
         super().check_1d()

--- a/src/queens/distributions/multinomial.py
+++ b/src/queens/distributions/multinomial.py
@@ -14,6 +14,8 @@
 #
 """Multinomial distribution."""
 
+from typing import override
+
 import numpy as np
 from numpy.typing import ArrayLike
 from scipy.stats import multinomial
@@ -45,6 +47,7 @@ class Multinomial(Discrete):
         super().__init__(probabilities_array, sample_space, dimension=len(probabilities_array))
         self.scipy_multinomial = multinomial(self.n_trials, self.probabilities)
 
+    @override
     def _compute_mean_and_covariance(self) -> tuple[np.ndarray, np.ndarray]:
         """Compute the mean value and covariance of the mixture model.
 
@@ -59,6 +62,7 @@ class Multinomial(Discrete):
         )
         return mean, covariance
 
+    @override
     def draw(self, num_draws: int = 1) -> np.ndarray:
         """Draw samples.
 
@@ -70,6 +74,7 @@ class Multinomial(Discrete):
         """
         return np.random.multinomial(self.n_trials, self.probabilities, size=num_draws)
 
+    @override
     def logpdf(self, x: np.ndarray) -> np.ndarray:
         """Log of the probability mass function.
 
@@ -81,6 +86,7 @@ class Multinomial(Discrete):
         """
         return self.scipy_multinomial.logpmf(x)
 
+    @override
     def pdf(self, x: np.ndarray) -> np.ndarray:
         """Probability mass function.
 
@@ -92,6 +98,7 @@ class Multinomial(Discrete):
         """
         return self.scipy_multinomial.pmf(x)
 
+    @override
     def cdf(self, x: np.ndarray) -> None:
         """Cumulative distribution function.
 
@@ -100,6 +107,7 @@ class Multinomial(Discrete):
         """
         super().check_1d()
 
+    @override
     def ppf(self, quantiles: np.ndarray) -> None:
         """Percent point function (inverse of CDF - quantiles).
 

--- a/src/queens/distributions/normal.py
+++ b/src/queens/distributions/normal.py
@@ -14,6 +14,8 @@
 #
 """Normal distribution."""
 
+from typing import override
+
 import numpy as np
 import scipy.stats
 from numpy.typing import ArrayLike
@@ -77,6 +79,7 @@ class Normal(Continuous):
         self.precision = precision
         self.logpdf_const = logpdf_const
 
+    @override
     def cdf(self, x: np.ndarray) -> np.ndarray:
         """Cumulative distribution function.
 
@@ -91,6 +94,7 @@ class Normal(Continuous):
         ).reshape(-1)
         return cdf
 
+    @override
     def draw(self, num_draws: int = 1) -> np.ndarray:
         """Draw samples.
 
@@ -104,6 +108,7 @@ class Normal(Continuous):
         samples = self.mean + np.dot(self.low_chol, uncorrelated_vector).T
         return samples
 
+    @override
     def logpdf(self, x: np.ndarray) -> np.ndarray:
         """Log of the probability density function.
 
@@ -117,6 +122,7 @@ class Normal(Continuous):
         logpdf = self.logpdf_const - 0.5 * (np.dot(dist, self.precision) * dist).sum(axis=1)
         return logpdf
 
+    @override
     def grad_logpdf(self, x: np.ndarray) -> np.ndarray:
         """Gradient of the log-PDF with respect to *x*.
 
@@ -130,6 +136,7 @@ class Normal(Continuous):
         grad_logpdf = np.dot(self.mean.reshape(1, -1) - x, self.precision)
         return grad_logpdf
 
+    @override
     def ppf(self, quantiles: ArrayLike) -> np.ndarray:
         """Percent point function (inverse of CDF — quantiles).
 

--- a/src/queens/distributions/normal.py
+++ b/src/queens/distributions/normal.py
@@ -81,14 +81,6 @@ class Normal(Continuous):
 
     @override
     def cdf(self, x: np.ndarray) -> np.ndarray:
-        """Cumulative distribution function.
-
-        Args:
-            x: Positions at which the CDF is evaluated
-
-        Returns:
-            CDF at positions
-        """
         cdf = scipy.stats.multivariate_normal.cdf(
             x.reshape(-1, self.dimension), mean=self.mean, cov=self.covariance
         ).reshape(-1)
@@ -96,56 +88,24 @@ class Normal(Continuous):
 
     @override
     def draw(self, num_draws: int = 1) -> np.ndarray:
-        """Draw samples.
-
-        Args:
-            num_draws: Number of draws
-
-        Returns:
-            Drawn samples from the distribution
-        """
         uncorrelated_vector = np.random.randn(self.dimension, num_draws)
         samples = self.mean + np.dot(self.low_chol, uncorrelated_vector).T
         return samples
 
     @override
     def logpdf(self, x: np.ndarray) -> np.ndarray:
-        """Log of the probability density function.
-
-        Args:
-            x: Positions at which the log-PDF is evaluated
-
-        Returns:
-            Log-PDF at positions
-        """
         dist = x.reshape(-1, self.dimension) - self.mean
         logpdf = self.logpdf_const - 0.5 * (np.dot(dist, self.precision) * dist).sum(axis=1)
         return logpdf
 
     @override
     def grad_logpdf(self, x: np.ndarray) -> np.ndarray:
-        """Gradient of the log-PDF with respect to *x*.
-
-        Args:
-            x: Positions at which the gradient of log-PDF is evaluated
-
-        Returns:
-            Gradient of the log-PDF evaluated at positions
-        """
         x = x.reshape(-1, self.dimension)
         grad_logpdf = np.dot(self.mean.reshape(1, -1) - x, self.precision)
         return grad_logpdf
 
     @override
     def ppf(self, quantiles: ArrayLike) -> np.ndarray:
-        """Percent point function (inverse of CDF — quantiles).
-
-        Args:
-            quantiles: Quantiles at which the PPF is evaluated
-
-        Returns:
-            Positions which correspond to given quantiles
-        """
         self.check_1d()
         ppf = scipy.stats.norm.ppf(
             quantiles, loc=self.mean, scale=self.covariance ** (1 / 2)

--- a/src/queens/distributions/particle.py
+++ b/src/queens/distributions/particle.py
@@ -16,6 +16,7 @@
 
 import itertools
 import logging
+from typing import override
 
 import numpy as np
 
@@ -44,6 +45,7 @@ class Particle(Discrete):
         sample_space: Samples, i.e. possible outcomes of sampling the distribution
     """
 
+    @override
     def _compute_mean_and_covariance(self) -> tuple[np.ndarray, np.ndarray]:
         """Compute the mean value and covariance of the mixture model.
 
@@ -61,6 +63,7 @@ class Particle(Discrete):
         )
         return mean, covariance
 
+    @override
     def cdf(self, x: np.ndarray) -> np.ndarray:
         """Cumulative distribution function.
 
@@ -74,6 +77,7 @@ class Particle(Discrete):
         closest_sample_event = np.searchsorted(self.sample_space.flatten(), x.flatten())
         return np.array([np.sum(self.probabilities[: (idx + 1)]) for idx in closest_sample_event])
 
+    @override
     def draw(self, num_draws: int = 1) -> np.ndarray:
         """Draw samples.
 
@@ -97,6 +101,7 @@ class Particle(Discrete):
         np.random.shuffle(samples)
         return samples.reshape(-1, 1)
 
+    @override
     def logpdf(self, x: np.ndarray) -> np.ndarray:
         """Log of the probability mass function.
 
@@ -108,6 +113,7 @@ class Particle(Discrete):
         """
         return np.log(self.pdf(x))
 
+    @override
     def pdf(self, x: np.ndarray) -> np.ndarray:
         """Probability mass function.
 
@@ -126,6 +132,7 @@ class Particle(Discrete):
 
         return self.probabilities[index]
 
+    @override
     def ppf(self, quantiles: np.ndarray) -> np.ndarray:
         """Percent point function (inverse of CDF-quantiles).
 

--- a/src/queens/distributions/particle.py
+++ b/src/queens/distributions/particle.py
@@ -47,12 +47,6 @@ class Particle(Discrete):
 
     @override
     def _compute_mean_and_covariance(self) -> tuple[np.ndarray, np.ndarray]:
-        """Compute the mean value and covariance of the mixture model.
-
-        Returns:
-            mean: Mean value of the distribution
-            covariance: Covariance of the distribution
-        """
         mean = np.sum(
             self.sample_space
             * np.tile(self.probabilities.reshape(-1, 1), len(self.sample_space[0])),
@@ -65,28 +59,12 @@ class Particle(Discrete):
 
     @override
     def cdf(self, x: np.ndarray) -> np.ndarray:
-        """Cumulative distribution function.
-
-        Args:
-            x: Positions at which the CDF is evaluated
-
-        Returns:
-            CDF value of the distribution
-        """
         self.check_1d()
         closest_sample_event = np.searchsorted(self.sample_space.flatten(), x.flatten())
         return np.array([np.sum(self.probabilities[: (idx + 1)]) for idx in closest_sample_event])
 
     @override
     def draw(self, num_draws: int = 1) -> np.ndarray:
-        """Draw samples.
-
-        Args:
-            num_draws: Number of draws
-
-        Returns:
-            Drawn samples
-        """
         samples_per_event = np.random.multinomial(num_draws, self.probabilities)
         samples_tuple = (
             [
@@ -103,26 +81,10 @@ class Particle(Discrete):
 
     @override
     def logpdf(self, x: np.ndarray) -> np.ndarray:
-        """Log of the probability mass function.
-
-        Args:
-            x: Positions at which the log-PDF is evaluated
-
-        Returns:
-            Log-PDF at positions
-        """
         return np.log(self.pdf(x))
 
     @override
     def pdf(self, x: np.ndarray) -> np.ndarray:
-        """Probability mass function.
-
-        Args:
-            x: Positions at which the PDF is evaluated
-
-        Returns:
-            PDF at positions
-        """
         index = np.array([(self.sample_space == xi).all(axis=1).nonzero()[0] for xi in x]).flatten()
 
         if len(index) != len(x):
@@ -134,14 +96,6 @@ class Particle(Discrete):
 
     @override
     def ppf(self, quantiles: np.ndarray) -> np.ndarray:
-        """Percent point function (inverse of CDF-quantiles).
-
-        Args:
-            quantiles: Quantiles at which the PPF is evaluated
-
-        Returns:
-            Event samples corresponding to the quantiles
-        """
         self.check_1d()
         indices = np.searchsorted(np.cumsum(self.probabilities), quantiles, side="left")
         indices = np.clip(indices, 0, len(self.probabilities))

--- a/src/queens/distributions/truncated_normal.py
+++ b/src/queens/distributions/truncated_normal.py
@@ -14,6 +14,8 @@
 #
 """Truncated normal distribution."""
 
+from typing import override
+
 import numpy as np
 import scipy.stats
 from numpy.typing import ArrayLike
@@ -90,6 +92,7 @@ class TruncatedNormal(Continuous):
             dimension=1,
         )
 
+    @override
     def cdf(self, x: np.ndarray) -> np.ndarray:
         """Cumulative distribution function.
 
@@ -102,6 +105,7 @@ class TruncatedNormal(Continuous):
         cdf = self.scipy_truncnorm.cdf(x).reshape(-1)
         return cdf
 
+    @override
     def draw(self, num_draws: int = 1) -> np.ndarray:
         """Draw samples.
 
@@ -114,6 +118,7 @@ class TruncatedNormal(Continuous):
         samples = self.scipy_truncnorm.rvs(size=num_draws).reshape(-1, 1)
         return samples
 
+    @override
     def logpdf(self, x: np.ndarray) -> np.ndarray:
         """Log of the probability density function.
 
@@ -126,6 +131,7 @@ class TruncatedNormal(Continuous):
         logpdf = self.scipy_truncnorm.logpdf(x).reshape(-1)
         return logpdf
 
+    @override
     def grad_logpdf(self, x: np.ndarray) -> np.ndarray:
         """Gradient of the log-PDF with respect to x.
 
@@ -139,6 +145,7 @@ class TruncatedNormal(Continuous):
         grad_logpdf = (self.unbounded_mean - x) / self.unbounded_std**2
         return grad_logpdf
 
+    @override
     def pdf(self, x: np.ndarray) -> np.ndarray:
         """Probability density function.
 
@@ -151,6 +158,7 @@ class TruncatedNormal(Continuous):
         pdf = self.scipy_truncnorm.pdf(x).reshape(-1)
         return pdf
 
+    @override
     def ppf(self, quantiles: np.ndarray) -> np.ndarray:
         """Percent point function (inverse of CDF — quantiles).
 

--- a/src/queens/distributions/truncated_normal.py
+++ b/src/queens/distributions/truncated_normal.py
@@ -94,53 +94,21 @@ class TruncatedNormal(Continuous):
 
     @override
     def cdf(self, x: np.ndarray) -> np.ndarray:
-        """Cumulative distribution function.
-
-        Args:
-            x: Positions at which the CDF is evaluated
-
-        Returns:
-            CDF at positions
-        """
         cdf = self.scipy_truncnorm.cdf(x).reshape(-1)
         return cdf
 
     @override
     def draw(self, num_draws: int = 1) -> np.ndarray:
-        """Draw samples.
-
-        Args:
-            num_draws: Number of draws
-
-        Returns:
-            Drawn samples from the distribution
-        """
         samples = self.scipy_truncnorm.rvs(size=num_draws).reshape(-1, 1)
         return samples
 
     @override
     def logpdf(self, x: np.ndarray) -> np.ndarray:
-        """Log of the probability density function.
-
-        Args:
-            x: Positions at which the log-PDF is evaluated
-
-        Returns:
-            Log-PDF at positions
-        """
         logpdf = self.scipy_truncnorm.logpdf(x).reshape(-1)
         return logpdf
 
     @override
     def grad_logpdf(self, x: np.ndarray) -> np.ndarray:
-        """Gradient of the log-PDF with respect to x.
-
-        Args:
-            x: Positions at which the gradient of the log-PDF is evaluated
-
-        Returns:
-            Gradient of the log-PDF at positions
-        """
         x = np.asarray(x).reshape(-1)
         grad_logpdf = (self.unbounded_mean - x) / self.unbounded_std**2
         return grad_logpdf
@@ -152,13 +120,5 @@ class TruncatedNormal(Continuous):
 
     @override
     def ppf(self, quantiles: np.ndarray) -> np.ndarray:
-        """Percent point function (inverse of CDF — quantiles).
-
-        Args:
-            quantiles: Quantiles at which the PPF is evaluated
-
-        Returns:
-            Positions which correspond to given quantiles
-        """
         ppf = self.scipy_truncnorm.ppf(quantiles).reshape(-1)
         return ppf

--- a/src/queens/distributions/truncated_normal.py
+++ b/src/queens/distributions/truncated_normal.py
@@ -147,14 +147,6 @@ class TruncatedNormal(Continuous):
 
     @override
     def pdf(self, x: np.ndarray) -> np.ndarray:
-        """Probability density function.
-
-        Args:
-            x: Positions at which the PDF is evaluated
-
-        Returns:
-            PDF at positions
-        """
         pdf = self.scipy_truncnorm.pdf(x).reshape(-1)
         return pdf
 

--- a/src/queens/distributions/uniform.py
+++ b/src/queens/distributions/uniform.py
@@ -127,14 +127,6 @@ class Uniform(Continuous):
 
     @override
     def pdf(self, x: np.ndarray) -> np.ndarray:
-        """Probability density function.
-
-        Args:
-            x: Positions at which the PDF is evaluated
-
-        Returns:
-            PDF at positions
-        """
         x = x.reshape(-1, self.dimension)
         # Check if positions are within bounds of the uniform distribution
         within_bounds = (x >= self.lower_bound).all(axis=1) * (x <= self.upper_bound).all(axis=1)

--- a/src/queens/distributions/uniform.py
+++ b/src/queens/distributions/uniform.py
@@ -63,14 +63,6 @@ class Uniform(Continuous):
 
     @override
     def cdf(self, x: np.ndarray) -> np.ndarray:
-        """Cumulative distribution function.
-
-        Args:
-            x: Positions at which the CDF is evaluated
-
-        Returns:
-            CDF at positions
-        """
         cdf = np.prod(
             np.clip(
                 (x.reshape(-1, self.dimension) - self.lower_bound) / self.width,
@@ -83,14 +75,6 @@ class Uniform(Continuous):
 
     @override
     def draw(self, num_draws: int = 1) -> np.ndarray:
-        """Draw samples.
-
-        Args:
-            num_draws: Number of draws
-
-        Returns:
-            Drawn samples from the distribution
-        """
         samples = np.random.uniform(
             low=self.lower_bound, high=self.upper_bound, size=(num_draws, self.dimension)
         )
@@ -98,14 +82,6 @@ class Uniform(Continuous):
 
     @override
     def logpdf(self, x: np.ndarray) -> np.ndarray:
-        """Log of the probability density function.
-
-        Args:
-            x: Positions at which the log-PDF is evaluated
-
-        Returns:
-            Log-PDF at positions
-        """
         x = x.reshape(-1, self.dimension)
         within_bounds = (x >= self.lower_bound).all(axis=1) * (x <= self.upper_bound).all(axis=1)
         logpdf = np.where(within_bounds, self.logpdf_const, -np.inf)
@@ -113,14 +89,6 @@ class Uniform(Continuous):
 
     @override
     def grad_logpdf(self, x: np.ndarray) -> np.ndarray:
-        """Gradient of the log-PDF with respect to *x*.
-
-        Args:
-            x: Positions at which the gradient of log-PDF is evaluated
-
-        Returns:
-            Gradient of the log-PDF evaluated at positions
-        """
         x = x.reshape(-1, self.dimension)
         grad_logpdf = np.zeros(x.shape)
         return grad_logpdf
@@ -135,14 +103,6 @@ class Uniform(Continuous):
 
     @override
     def ppf(self, quantiles: np.ndarray) -> np.ndarray:
-        """Percent point function (inverse of cdf — quantiles).
-
-        Args:
-            quantiles: Quantiles at which the PPF is evaluated
-
-        Returns:
-            Positions which correspond to given quantiles
-        """
         self.check_1d()
         ppf = scipy.stats.uniform.ppf(q=quantiles, loc=self.lower_bound, scale=self.width).reshape(
             -1

--- a/src/queens/distributions/uniform.py
+++ b/src/queens/distributions/uniform.py
@@ -14,6 +14,8 @@
 #
 """Uniform distribution."""
 
+from typing import override
+
 import numpy as np
 import scipy.stats
 from numpy.typing import ArrayLike
@@ -59,6 +61,7 @@ class Uniform(Continuous):
         self.pdf_const = pdf_const
         self.logpdf_const = logpdf_const
 
+    @override
     def cdf(self, x: np.ndarray) -> np.ndarray:
         """Cumulative distribution function.
 
@@ -78,6 +81,7 @@ class Uniform(Continuous):
         )
         return cdf
 
+    @override
     def draw(self, num_draws: int = 1) -> np.ndarray:
         """Draw samples.
 
@@ -92,6 +96,7 @@ class Uniform(Continuous):
         )
         return samples
 
+    @override
     def logpdf(self, x: np.ndarray) -> np.ndarray:
         """Log of the probability density function.
 
@@ -106,6 +111,7 @@ class Uniform(Continuous):
         logpdf = np.where(within_bounds, self.logpdf_const, -np.inf)
         return logpdf
 
+    @override
     def grad_logpdf(self, x: np.ndarray) -> np.ndarray:
         """Gradient of the log-PDF with respect to *x*.
 
@@ -119,6 +125,7 @@ class Uniform(Continuous):
         grad_logpdf = np.zeros(x.shape)
         return grad_logpdf
 
+    @override
     def pdf(self, x: np.ndarray) -> np.ndarray:
         """Probability density function.
 
@@ -134,6 +141,7 @@ class Uniform(Continuous):
         pdf = within_bounds * self.pdf_const
         return pdf
 
+    @override
     def ppf(self, quantiles: np.ndarray) -> np.ndarray:
         """Percent point function (inverse of cdf — quantiles).
 

--- a/src/queens/parameters/random_fields/_random_field.py
+++ b/src/queens/parameters/random_fields/_random_field.py
@@ -51,10 +51,10 @@ class RandomField(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def draw(self, num_samples: int) -> np.ndarray:
-        """Draw samples of the latent space.
+        """Draw samples from the latent representation of the random field.
 
         Args:
-            num_samples (int): Batch size of samples to draw
+            num_samples: Number of draws of latent random samples
 
         Returns:
             Drawn samples

--- a/src/queens/parameters/random_fields/fourier.py
+++ b/src/queens/parameters/random_fields/fourier.py
@@ -14,7 +14,7 @@
 #
 """Fourier Random fields class."""
 
-from typing import TypeAlias
+from typing import TypeAlias, override
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -127,6 +127,7 @@ class Fourier(RandomField):
             self.latent_index,
         )
 
+    @override
     def draw(self, num_samples: int) -> np.ndarray:
         """Draw samples from the latent representation of the random field.
 
@@ -138,6 +139,7 @@ class Fourier(RandomField):
         """
         return self.distribution.draw(num_samples)
 
+    @override
     def logpdf(self, samples: np.ndarray) -> np.ndarray:
         """Get joint log-PDF of latent space.
 
@@ -150,6 +152,7 @@ class Fourier(RandomField):
         logpdf = self.distribution.logpdf(samples)
         return logpdf
 
+    @override
     def grad_logpdf(self, samples: np.ndarray) -> np.ndarray:
         """Get gradient of joint log-PDF of latent space.
 
@@ -166,6 +169,7 @@ class Fourier(RandomField):
 
         return self.distribution.grad_logpdf(samples)
 
+    @override
     def expanded_representation(self, samples: np.ndarray) -> np.ndarray:
         """Expand latent representation of samples.
 
@@ -178,6 +182,7 @@ class Fourier(RandomField):
         sample_expanded = self.mean + self.std * np.matmul(samples, self.basis.T)
         return sample_expanded
 
+    @override
     def latent_gradient(self, upstream_gradient: np.ndarray) -> np.ndarray:
         """Gradient with respect to the latent parameters.
 

--- a/src/queens/parameters/random_fields/fourier.py
+++ b/src/queens/parameters/random_fields/fourier.py
@@ -129,39 +129,15 @@ class Fourier(RandomField):
 
     @override
     def draw(self, num_samples: int) -> np.ndarray:
-        """Draw samples from the latent representation of the random field.
-
-        Args:
-            num_samples: Number of draws of latent random samples
-
-        Returns:
-            Drawn samples
-        """
         return self.distribution.draw(num_samples)
 
     @override
     def logpdf(self, samples: np.ndarray) -> np.ndarray:
-        """Get joint log-PDF of latent space.
-
-        Args:
-            samples: Samples for evaluating the log-PDF
-
-        Returns:
-            Log-PDF of the samples
-        """
         logpdf = self.distribution.logpdf(samples)
         return logpdf
 
     @override
     def grad_logpdf(self, samples: np.ndarray) -> np.ndarray:
-        """Get gradient of joint log-PDF of latent space.
-
-        Args:
-            samples: Samples for evaluating the gradient of the log-PDF
-
-        Returns:
-            Gradient of the log-PDF
-        """
         if not isinstance(self.distribution, HasGradLogPDF):
             raise TypeError(
                 f"The distribution {self.distribution} does not have a grad_logpdf function."
@@ -171,28 +147,11 @@ class Fourier(RandomField):
 
     @override
     def expanded_representation(self, samples: np.ndarray) -> np.ndarray:
-        """Expand latent representation of samples.
-
-        Args:
-            samples: Latent representation of samples
-
-        Returns:
-            Expanded representation of samples
-        """
         sample_expanded = self.mean + self.std * np.matmul(samples, self.basis.T)
         return sample_expanded
 
     @override
     def latent_gradient(self, upstream_gradient: np.ndarray) -> np.ndarray:
-        """Gradient with respect to the latent parameters.
-
-        Args:
-            upstream_gradient: Gradient with respect to all coords of the field
-
-        Returns:
-            Gradient of the realization of the random field with respect to the latent space
-                variables
-        """
         latent_grad = self.std * np.matmul(upstream_gradient, self.basis)
         return latent_grad
 

--- a/src/queens/parameters/random_fields/karhunen_loeve.py
+++ b/src/queens/parameters/random_fields/karhunen_loeve.py
@@ -153,14 +153,6 @@ class KarhunenLoeve(RandomField):
 
     @override
     def latent_gradient(self, upstream_gradient: np.ndarray) -> np.ndarray:
-        """Gradient of the field with respect to the latent parameters.
-
-        Args:
-            upstream_gradient: Gradient with respect to all coords of the field
-
-        Returns:
-            Gradient of the field with respect to the latent parameters
-        """
         if self.eigenbasis is None:
             raise ValueError("Eigenbasis has not been computed yet.")
 

--- a/src/queens/parameters/random_fields/karhunen_loeve.py
+++ b/src/queens/parameters/random_fields/karhunen_loeve.py
@@ -96,38 +96,14 @@ class KarhunenLoeve(RandomField):
 
     @override
     def draw(self, num_samples: int) -> np.ndarray:
-        """Draw samples from the latent representation of the random field.
-
-        Args:
-            num_samples: Number of draws of latent random samples
-
-        Returns:
-            Drawn samples
-        """
         return self.distribution.draw(num_samples)
 
     @override
     def logpdf(self, samples: np.ndarray) -> np.ndarray:
-        """Get joint log-PDF of latent space.
-
-        Args:
-            samples: Samples for evaluating the log-PDF
-
-        Returns:
-            Log-PDF of the samples
-        """
         return self.distribution.logpdf(samples)
 
     @override
     def grad_logpdf(self, samples: np.ndarray) -> np.ndarray:
-        """Get gradient of joint log-PDF of latent space.
-
-        Args:
-            samples: Samples for evaluating the gradient of the log-PDF
-
-        Returns:
-            Gradient of the log-PDF
-        """
         if not isinstance(self.distribution, HasGradLogPDF):
             raise TypeError(
                 f"The distribution {self.distribution} does not have a grad_logpdf function."
@@ -137,14 +113,6 @@ class KarhunenLoeve(RandomField):
 
     @override
     def expanded_representation(self, samples: np.ndarray) -> np.ndarray:
-        """Expand latent representation of samples.
-
-        Args:
-            samples: Latent representation of samples
-
-        Returns:
-            Expanded representation of samples
-        """
         if self.eigenbasis is None:
             raise ValueError("Eigenbasis has not been computed yet.")
 

--- a/src/queens/parameters/random_fields/karhunen_loeve.py
+++ b/src/queens/parameters/random_fields/karhunen_loeve.py
@@ -15,6 +15,7 @@
 """Karhunen-Loève Random fields class."""
 
 import logging
+from typing import override
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -93,6 +94,7 @@ class KarhunenLoeve(RandomField):
 
         super().__init__(coords, distribution, dimension=dimension)
 
+    @override
     def draw(self, num_samples: int) -> np.ndarray:
         """Draw samples from the latent representation of the random field.
 
@@ -104,6 +106,7 @@ class KarhunenLoeve(RandomField):
         """
         return self.distribution.draw(num_samples)
 
+    @override
     def logpdf(self, samples: np.ndarray) -> np.ndarray:
         """Get joint log-PDF of latent space.
 
@@ -115,6 +118,7 @@ class KarhunenLoeve(RandomField):
         """
         return self.distribution.logpdf(samples)
 
+    @override
     def grad_logpdf(self, samples: np.ndarray) -> np.ndarray:
         """Get gradient of joint log-PDF of latent space.
 
@@ -131,6 +135,7 @@ class KarhunenLoeve(RandomField):
 
         return self.distribution.grad_logpdf(samples)
 
+    @override
     def expanded_representation(self, samples: np.ndarray) -> np.ndarray:
         """Expand latent representation of samples.
 
@@ -146,6 +151,7 @@ class KarhunenLoeve(RandomField):
         samples_expanded = self.mean + np.matmul(samples, self.eigenbasis.T)
         return samples_expanded
 
+    @override
     def latent_gradient(self, upstream_gradient: np.ndarray) -> np.ndarray:
         """Gradient of the field with respect to the latent parameters.
 

--- a/src/queens/parameters/random_fields/piece_wise.py
+++ b/src/queens/parameters/random_fields/piece_wise.py
@@ -15,6 +15,7 @@
 """Piece-wise random fields class."""
 
 from copy import deepcopy
+from typing import override
 
 import numpy as np
 
@@ -48,6 +49,7 @@ class PieceWise(RandomField):
         self.latent_1d_distribution = latent_1d_distribution
         self.distribution.dimension = self.dimension
 
+    @override
     def draw(self, num_samples: int) -> np.ndarray:
         """Draw samples from the latent representation of the random field.
 
@@ -61,6 +63,7 @@ class PieceWise(RandomField):
         )
         return samples
 
+    @override
     def logpdf(self, samples: np.ndarray) -> np.ndarray:
         """Get joint log-PDF of latent space.
 
@@ -76,6 +79,7 @@ class PieceWise(RandomField):
             .sum(axis=1)
         )
 
+    @override
     def grad_logpdf(self, samples: np.ndarray) -> np.ndarray:
         """Get gradient of joint log-PDF of latent space.
 
@@ -95,6 +99,7 @@ class PieceWise(RandomField):
             samples.shape
         )
 
+    @override
     def expanded_representation(self, samples: np.ndarray) -> np.ndarray:
         """Expand latent representation of samples.
 
@@ -106,6 +111,7 @@ class PieceWise(RandomField):
         """
         return samples
 
+    @override
     def latent_gradient(self, upstream_gradient: np.ndarray) -> np.ndarray:
         """Gradient of the field with respect to the latent parameters.
 

--- a/src/queens/parameters/random_fields/piece_wise.py
+++ b/src/queens/parameters/random_fields/piece_wise.py
@@ -113,12 +113,4 @@ class PieceWise(RandomField):
 
     @override
     def latent_gradient(self, upstream_gradient: np.ndarray) -> np.ndarray:
-        """Gradient of the field with respect to the latent parameters.
-
-        Args:
-            upstream_gradient: Gradient with respect to all coords of the field
-
-        Returns:
-            Gradient of the field with respect to the latent parameters
-        """
         return upstream_gradient

--- a/src/queens/parameters/random_fields/piece_wise.py
+++ b/src/queens/parameters/random_fields/piece_wise.py
@@ -51,13 +51,6 @@ class PieceWise(RandomField):
 
     @override
     def draw(self, num_samples: int) -> np.ndarray:
-        """Draw samples from the latent representation of the random field.
-
-        Args:
-            num_samples: Number of draws of latent random samples
-        Returns:
-            Drawn samples
-        """
         samples = self.latent_1d_distribution.draw(num_samples * self.dimension).reshape(
             num_samples, self.dimension
         )
@@ -65,14 +58,6 @@ class PieceWise(RandomField):
 
     @override
     def logpdf(self, samples: np.ndarray) -> np.ndarray:
-        """Get joint log-PDF of latent space.
-
-        Args:
-            samples: Latent space samples
-
-        Returns:
-            Log-PDF of the samples
-        """
         return (
             self.latent_1d_distribution.logpdf(samples.reshape(-1, 1))
             .reshape(samples.shape)
@@ -81,14 +66,6 @@ class PieceWise(RandomField):
 
     @override
     def grad_logpdf(self, samples: np.ndarray) -> np.ndarray:
-        """Get gradient of joint log-PDF of latent space.
-
-        Args:
-            samples: Latent space samples
-
-        Returns:
-            Gradient of the log-PDF of the samples
-        """
         if not isinstance(self.latent_1d_distribution, HasGradLogPDF):
             raise TypeError(
                 f"The latent 1D distribution {self.latent_1d_distribution} does not have a "
@@ -101,14 +78,6 @@ class PieceWise(RandomField):
 
     @override
     def expanded_representation(self, samples: np.ndarray) -> np.ndarray:
-        """Expand latent representation of samples.
-
-        Args:
-            samples: Latent representation of samples
-
-        Returns:
-            Expanded representation of samples
-        """
         return samples
 
     @override

--- a/src/queens/utils/classifier.py
+++ b/src/queens/utils/classifier.py
@@ -16,6 +16,7 @@
 
 import pickle
 from pathlib import Path
+from typing import override
 
 import numpy as np
 from skactiveml.classifier import SklearnClassifier
@@ -120,6 +121,7 @@ class ActiveLearningClassifier(Classifier):
             self.active_sampler_obj = UncertaintySampling(method="entropy", random_state=0)
         self.batch_size = batch_size
 
+    @override
     def train(  # type: ignore[override]
         self, x_train: np.ndarray, y_train: np.ndarray
     ) -> np.ndarray:

--- a/src/queens/utils/collection.py
+++ b/src/queens/utils/collection.py
@@ -16,7 +16,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable
+from typing import Iterable, override
 
 from queens.utils.printing import get_str_table
 
@@ -86,6 +86,7 @@ class CollectionObject:
         """
         return [len(value) for value in self.values()]
 
+    @override
     def __str__(self) -> str:
         """Print table of current collection.
 

--- a/src/queens/utils/iterative_averaging.py
+++ b/src/queens/utils/iterative_averaging.py
@@ -15,7 +15,7 @@
 """Iterative averaging utils."""
 
 import abc
-from typing import Callable, TypeAlias
+from typing import Callable, TypeAlias, override
 
 import numpy as np
 
@@ -87,6 +87,7 @@ class IterativeAveraging(metaclass=abc.ABCMeta):
         }
         return print_dict
 
+    @override
     def __str__(self) -> str:
         """String of iterative averager.
 
@@ -122,6 +123,7 @@ class MovingAveraging(IterativeAveraging):
         self.num_iter_for_avg: int = num_iter_for_avg
         self.data: list = []
 
+    @override
     def average_computation(self, new_value: NumericalValue) -> NumpyValue:
         """Compute the moving average.
 
@@ -141,6 +143,7 @@ class MovingAveraging(IterativeAveraging):
             average += data
         return average / len(self.data)
 
+    @override
     def _get_print_dict(self) -> dict:
         """Get print dict.
 
@@ -172,6 +175,7 @@ class PolyakAveraging(IterativeAveraging):
         self.iteration_counter: int = 1
         self.sum_over_iter: NumpyValue = np.float64(0.0)
 
+    @override
     def average_computation(self, new_value: NumericalValue) -> NumpyValue:
         """Compute the Polyak average.
 
@@ -193,6 +197,7 @@ class PolyakAveraging(IterativeAveraging):
 
         return current_average
 
+    @override
     def _get_print_dict(self) -> dict:
         """Get print dict.
 
@@ -232,6 +237,7 @@ class ExponentialAveraging(IterativeAveraging):
         super().__init__()
         self.coefficient: float = coefficient
 
+    @override
     def average_computation(  # type: ignore[override]
         self, new_value: NumericalValue
     ) -> NumericalValue:
@@ -251,6 +257,7 @@ class ExponentialAveraging(IterativeAveraging):
         )
         return current_average
 
+    @override
     def _get_print_dict(self) -> dict:
         """Get print dict.
 

--- a/src/queens/utils/iterative_averaging.py
+++ b/src/queens/utils/iterative_averaging.py
@@ -145,11 +145,6 @@ class MovingAveraging(IterativeAveraging):
 
     @override
     def _get_print_dict(self) -> dict:
-        """Get print dict.
-
-        Returns:
-            Dictionary with data to print
-        """
         print_dict = super()._get_print_dict()
         print_dict.update({"Averaging window size": self.num_iter_for_avg})
 
@@ -199,11 +194,6 @@ class PolyakAveraging(IterativeAveraging):
 
     @override
     def _get_print_dict(self) -> dict:
-        """Get print dict.
-
-        Returns:
-            Dictionary with data to print
-        """
         print_dict = super()._get_print_dict()
         print_dict.update({"Number of iterations": self.iteration_counter})
 
@@ -259,11 +249,6 @@ class ExponentialAveraging(IterativeAveraging):
 
     @override
     def _get_print_dict(self) -> dict:
-        """Get print dict.
-
-        Returns:
-            Dictionary with data to print
-        """
         print_dict = super()._get_print_dict()
         print_dict.update({"Coefficient": self.coefficient})
 

--- a/src/queens/utils/iterative_averaging.py
+++ b/src/queens/utils/iterative_averaging.py
@@ -72,7 +72,14 @@ class IterativeAveraging(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def average_computation(self, new_value: NumericalValue) -> NumpyValue:
-        """Here, the averaging approach is implemented."""
+        """Compute the current average.
+
+        Args:
+            new_value: New value to update the average
+
+        Returns:
+            The current average
+        """
 
     def _get_print_dict(self) -> dict:
         """Get print dict.
@@ -125,14 +132,6 @@ class MovingAveraging(IterativeAveraging):
 
     @override
     def average_computation(self, new_value: NumericalValue) -> NumpyValue:
-        """Compute the moving average.
-
-        Args:
-            new_value: New value to update the average
-
-        Returns:
-            The current average
-        """
         if isinstance(new_value, (np.floating, np.ndarray)):
             new_value = new_value.copy()
         self.data.append(new_value)
@@ -172,14 +171,6 @@ class PolyakAveraging(IterativeAveraging):
 
     @override
     def average_computation(self, new_value: NumericalValue) -> NumpyValue:
-        """Compute the Polyak average.
-
-        Args:
-            new_value: New value to update the average
-
-        Returns:
-            Returns the current average
-        """
         if isinstance(new_value, (np.ndarray)) and not isinstance(self.sum_over_iter, np.ndarray):
             self.sum_over_iter = np.zeros_like(new_value)
 
@@ -231,14 +222,6 @@ class ExponentialAveraging(IterativeAveraging):
     def average_computation(  # type: ignore[override]
         self, new_value: NumericalValue
     ) -> NumericalValue:
-        """Compute the exponential average.
-
-        Args:
-            new_value: New value to update the average.
-
-        Returns:
-            Returns the current average
-        """
         if self.current_average is None:
             raise ValueError("Current average has not been initialized.")
 

--- a/src/queens/utils/iterative_averaging.py
+++ b/src/queens/utils/iterative_averaging.py
@@ -132,6 +132,14 @@ class MovingAveraging(IterativeAveraging):
 
     @override
     def average_computation(self, new_value: NumericalValue) -> NumpyValue:
+        """Compute the moving average.
+
+        Args:
+            new_value: New value to update the average
+
+        Returns:
+            The current average
+        """
         if isinstance(new_value, (np.floating, np.ndarray)):
             new_value = new_value.copy()
         self.data.append(new_value)
@@ -171,6 +179,14 @@ class PolyakAveraging(IterativeAveraging):
 
     @override
     def average_computation(self, new_value: NumericalValue) -> NumpyValue:
+        """Compute the Polyak average.
+
+        Args:
+            new_value: New value to update the average
+
+        Returns:
+            Returns the current average
+        """
         if isinstance(new_value, (np.ndarray)) and not isinstance(self.sum_over_iter, np.ndarray):
             self.sum_over_iter = np.zeros_like(new_value)
 
@@ -222,6 +238,14 @@ class ExponentialAveraging(IterativeAveraging):
     def average_computation(  # type: ignore[override]
         self, new_value: NumericalValue
     ) -> NumericalValue:
+        """Compute the exponential average.
+
+        Args:
+            new_value: New value to update the average.
+
+        Returns:
+            Returns the current average
+        """
         if self.current_average is None:
             raise ValueError("Current average has not been initialized.")
 

--- a/src/queens/utils/logger_settings.py
+++ b/src/queens/utils/logger_settings.py
@@ -19,7 +19,7 @@ import inspect
 import logging
 import sys
 from pathlib import Path
-from typing import Any, Callable, ParamSpec
+from typing import Any, Callable, ParamSpec, override
 
 from queens.utils.printing import get_str_table
 
@@ -42,6 +42,7 @@ class LogFilter(logging.Filter):
         super().__init__()
         self.level = level
 
+    @override
     def filter(self, record: logging.LogRecord) -> bool:
         """Filter the logging record.
 
@@ -62,6 +63,7 @@ class NewLineFormatter(logging.Formatter):
     format of the logging is broken for multiline messages.
     """
 
+    @override
     def format(self, record: logging.LogRecord) -> str:
         """Override format function.
 

--- a/src/queens/utils/metadata.py
+++ b/src/queens/utils/metadata.py
@@ -18,7 +18,7 @@ from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 from time import perf_counter
-from typing import Any, Iterator
+from typing import Any, Iterator, override
 
 import pandas as pd
 import yaml
@@ -120,6 +120,7 @@ class SimulationMetadata:
             # Export since the job is either finished or failed
             self.export()
 
+    @override
     def __str__(self) -> str:
         """Create function string.
 

--- a/src/queens/utils/scaling.py
+++ b/src/queens/utils/scaling.py
@@ -15,7 +15,7 @@
 """Utils for data scaling."""
 
 import abc
-from typing import Any
+from typing import Any, override
 
 import numpy as np
 
@@ -80,6 +80,7 @@ class StandardScaler(Scaler):
         self.mean: np.ndarray | None = None
         self.standard_deviation: np.ndarray | None = None
 
+    @override
     def fit(self, x_mat: np.ndarray) -> None:
         """Fit/calculate the scaling based on the input samples.
 
@@ -89,6 +90,7 @@ class StandardScaler(Scaler):
         self.mean = np.mean(x_mat)
         self.standard_deviation = np.std(x_mat)
 
+    @override
     def transform(self, x_mat: np.ndarray) -> np.ndarray:
         """Conduct the scaling transformation on the data matrix.
 
@@ -104,6 +106,7 @@ class StandardScaler(Scaler):
         transformed_data = (x_mat - self.mean) / self.standard_deviation
         return transformed_data
 
+    @override
     def inverse_transform_mean(self, x_mat: np.ndarray) -> np.ndarray:
         """Conduct the inverse scaling transformation on the data matrix.
 
@@ -120,6 +123,7 @@ class StandardScaler(Scaler):
 
         return transformed_data
 
+    @override
     def inverse_transform_std(self, x_mat: np.ndarray) -> np.ndarray:
         """Conduct the inverse scaling transformation.
 
@@ -188,6 +192,7 @@ class StandardScaler(Scaler):
 class IdentityScaler(Scaler):
     """The identity scaler."""
 
+    @override
     def fit(self, x_mat: np.ndarray) -> None:
         """Fit/calculate the scaling based on the input samples.
 
@@ -195,6 +200,7 @@ class IdentityScaler(Scaler):
             x_mat: Data matrix that should be standardized
         """
 
+    @override
     def transform(self, x_mat: np.ndarray) -> np.ndarray:
         """Conduct the scaling transformation on the data matrix.
 
@@ -206,6 +212,7 @@ class IdentityScaler(Scaler):
         """
         return x_mat
 
+    @override
     def inverse_transform_mean(self, x_mat: np.ndarray) -> np.ndarray:
         """Conduct the inverse scaling transformation on the data matrix.
 
@@ -217,6 +224,7 @@ class IdentityScaler(Scaler):
         """
         return x_mat
 
+    @override
     def inverse_transform_std(self, x_mat: np.ndarray) -> np.ndarray:
         """Conduct the inverse scaling.
 

--- a/src/queens/utils/scaling.py
+++ b/src/queens/utils/scaling.py
@@ -43,6 +43,9 @@ class Scaler(metaclass=abc.ABCMeta):
 
         Args:
             x_mat: Data matrix that should be standardized
+
+        Returns:
+            Transformed data-array
         """
 
     @abc.abstractmethod
@@ -51,14 +54,22 @@ class Scaler(metaclass=abc.ABCMeta):
 
         Args:
             x_mat: Data matrix that should be standardized
+
+        Returns:
+            Transformed data-array
         """
 
     @abc.abstractmethod
     def inverse_transform_std(self, x_mat: np.ndarray) -> np.ndarray:
         """Conduct the inverse transformation.
 
+        The data is transformed based on the standard deviation.
+
         Args:
             x_mat: Data matrix that should be standardized
+
+        Returns:
+            Transformed data-array
         """
 
 
@@ -87,14 +98,6 @@ class StandardScaler(Scaler):
 
     @override
     def transform(self, x_mat: np.ndarray) -> np.ndarray:
-        """Conduct the scaling transformation on the data matrix.
-
-        Args:
-            x_mat: Data matrix that should be standardized
-
-        Returns:
-            Transformed data-array
-        """
         if self.mean is None or self.standard_deviation is None:
             raise ValueError("Scaler has not been fitted yet.")
 
@@ -103,14 +106,6 @@ class StandardScaler(Scaler):
 
     @override
     def inverse_transform_mean(self, x_mat: np.ndarray) -> np.ndarray:
-        """Conduct the inverse scaling transformation on the data matrix.
-
-        Args:
-            x_mat: Data matrix that should be standardized
-
-        Returns:
-            Transformed data-array
-        """
         if self.mean is None or self.standard_deviation is None:
             raise ValueError("Scaler has not been fitted yet.")
 
@@ -120,16 +115,6 @@ class StandardScaler(Scaler):
 
     @override
     def inverse_transform_std(self, x_mat: np.ndarray) -> np.ndarray:
-        """Conduct the inverse scaling transformation.
-
-        The data is transformed based on the standard deviation.
-
-        Args:
-            x_mat: Data matrix that should be standardized
-
-        Returns:
-            Transformed data-array
-        """
         if self.standard_deviation is None:
             raise ValueError("Scaler has not been fitted yet.")
 
@@ -192,38 +177,14 @@ class IdentityScaler(Scaler):
 
     @override
     def transform(self, x_mat: np.ndarray) -> np.ndarray:
-        """Conduct the scaling transformation on the data matrix.
-
-        Args:
-            x_mat: Data matrix that should be standardized
-
-        Returns:
-            Transformed data-array
-        """
         return x_mat
 
     @override
     def inverse_transform_mean(self, x_mat: np.ndarray) -> np.ndarray:
-        """Conduct the inverse scaling transformation on the data matrix.
-
-        Args:
-            x_mat: Data matrix that should be standardized
-
-        Returns:
-            Transformed data-array
-        """
         return x_mat
 
     @override
     def inverse_transform_std(self, x_mat: np.ndarray) -> np.ndarray:
-        """Conduct the inverse scaling.
-
-        Args:
-            x_mat: Data matrix that should be standardized
-
-        Returns:
-            Transformed data-array
-        """
         return x_mat
 
     def inverse_transform_grad_mean(self, grad_mean: np.ndarray, *_args: Any) -> np.ndarray:

--- a/src/queens/utils/scaling.py
+++ b/src/queens/utils/scaling.py
@@ -82,11 +82,6 @@ class StandardScaler(Scaler):
 
     @override
     def fit(self, x_mat: np.ndarray) -> None:
-        """Fit/calculate the scaling based on the input samples.
-
-        Args:
-            x_mat: Data matrix that should be standardized
-        """
         self.mean = np.mean(x_mat)
         self.standard_deviation = np.std(x_mat)
 
@@ -193,12 +188,7 @@ class IdentityScaler(Scaler):
     """The identity scaler."""
 
     @override
-    def fit(self, x_mat: np.ndarray) -> None:
-        """Fit/calculate the scaling based on the input samples.
-
-        Args:
-            x_mat: Data matrix that should be standardized
-        """
+    def fit(self, x_mat: np.ndarray) -> None: ...
 
     @override
     def transform(self, x_mat: np.ndarray) -> np.ndarray:

--- a/src/queens/variational_distributions/_variational_distribution.py
+++ b/src/queens/variational_distributions/_variational_distribution.py
@@ -105,7 +105,7 @@ class Variational:
 
         Args:
             variational_parameters: Variational parameters
-            x: Locations to evaluate
+            x: Row-wise samples to evaluate
 
         Returns:
             Log-PDF values
@@ -121,7 +121,7 @@ class Variational:
 
         Args:
             variational_parameters: Variational parameters
-            x: Locations to evaluate
+            x: Row-wise samples to evaluate
 
         Returns:
             PDF values
@@ -133,13 +133,13 @@ class Variational:
         variational_parameters: ArrayNParams,
         x: ArrayNSamplesXNDims,
     ) -> ArrayNParamsXNSamples:
-        """Log-PDF gradient w.r.t. the variational parameters.
+        """Log-PDF gradient with respect to the variational parameters.
 
         Evaluated at samples  *x*. Also known as the score function.
 
         Args:
             variational_parameters: Variational parameters
-            x: Locations to evaluate
+            x: Row-wise samples to evaluate
 
         Returns:
             Gradient of the log-PDF w.r.t. the variational parameters

--- a/src/queens/variational_distributions/full_rank_normal.py
+++ b/src/queens/variational_distributions/full_rank_normal.py
@@ -307,8 +307,8 @@ class FullRankNormal(Variational):
 
         Returns:
             Gradients of the log-pdf with respect to the sample *x*. The first dimension of the
-            array corresponds to the different samples. The second dimension to different
-            dimensions within one sample.
+                array corresponds to the different samples. The second dimension to different
+                dimensions within one sample.
         """
         mean, cov = self.reconstruct_distribution_parameters(variational_parameters)
         gradient_lst = []

--- a/src/queens/variational_distributions/full_rank_normal.py
+++ b/src/queens/variational_distributions/full_rank_normal.py
@@ -14,7 +14,7 @@
 #
 """Full-Rank Normal Variational Distribution."""
 
-from typing import cast
+from typing import cast, override
 
 import numpy as np
 import scipy
@@ -66,6 +66,7 @@ class FullRankNormal(Variational):
         n_parameters = (dimension * (dimension + 1)) // 2 + dimension
         super().__init__(dimension, n_parameters)
 
+    @override
     def initialize_variational_parameters(self, random: bool = False) -> ArrayNParams:
         r"""Initialize variational parameters.
 
@@ -99,6 +100,7 @@ class FullRankNormal(Variational):
 
         return variational_parameters
 
+    @override
     def construct_variational_parameters(  # pylint: disable=arguments-differ
         self, mean: ArrayNDimsX1 | ArrayNDims, covariance: ArrayNDimsXNDims
     ) -> ArrayNParams:
@@ -125,6 +127,7 @@ class FullRankNormal(Variational):
             )
         return variational_parameters
 
+    @override
     def reconstruct_distribution_parameters(
         self, variational_parameters: ArrayNParams
     ) -> tuple[ArrayNDimsX1, ArrayNDimsXNDims]:
@@ -171,6 +174,7 @@ class FullRankNormal(Variational):
         grad_reconstruct_params = np.ones((1, self.n_parameters))
         return cast(Array1XNParams, grad_reconstruct_params)
 
+    @override
     def draw(self, variational_parameters: ArrayNParams, n_draws: NSamples) -> ArrayNSamplesXNDims:
         """Draw *n_draw* samples from the variational distribution.
 
@@ -187,6 +191,7 @@ class FullRankNormal(Variational):
         sample = np.dot(cholesky, np.random.randn(self.dimension, n_draws)).T + mean.reshape(1, -1)
         return sample
 
+    @override
     def logpdf(self, variational_parameters: ArrayNParams, x: ArrayNSamplesXNDims) -> ArrayNSamples:
         """Log-PDF evaluated at the samples *x*.
 
@@ -213,6 +218,7 @@ class FullRankNormal(Variational):
         )
         return logpdf.flatten()
 
+    @override
     def pdf(self, variational_parameters: ArrayNParams, x: ArrayNSamplesXNDims) -> ArrayNSamples:
         """PDF of evaluated at given samples *x*.
 
@@ -228,10 +234,11 @@ class FullRankNormal(Variational):
         pdf = np.exp(self.logpdf(variational_parameters, x))
         return pdf
 
+    @override
     def grad_params_logpdf(
         self, variational_parameters: ArrayNParams, x: ArrayNSamplesXNDims
     ) -> ArrayNParamsXNSamples:
-        """Log-PDF gradient w.r.t. to the variational parameters.
+        """Log-PDF gradient with respect to the variational parameters.
 
         Evaluated at samples *x*. Also known as the score function.
 
@@ -292,16 +299,16 @@ class FullRankNormal(Variational):
     def grad_sample_logpdf(
         self, variational_parameters: ArrayNParams, sample_batch: ArrayNSamplesXNDims
     ) -> ArrayNSamplesXNDims:
-        """Computes the gradient of the log-PDF w.r.t. to the sample *x*.
+        """Compute the gradient of the log-PDF with respect to the sample *x*.
 
         Args:
             variational_parameters: Variational parameters
             sample_batch: Row-wise samples
 
         Returns:
-            Gradients of the log-pdf w.r.t. the sample *x*. The first dimension of the array
-                corresponds to the different samples. The second dimension to different dimensions
-                within one sample.
+            Gradients of the log-pdf with respect to the sample *x*. The first dimension of the
+            array corresponds to the different samples. The second dimension to different
+            dimensions within one sample.
         """
         mean, cov = self.reconstruct_distribution_parameters(variational_parameters)
         gradient_lst = []
@@ -313,6 +320,7 @@ class FullRankNormal(Variational):
         gradients_batch = np.array(gradient_lst)
         return gradients_batch.reshape(sample_batch.shape)
 
+    @override
     def fisher_information_matrix(
         self, variational_parameters: ArrayNParams
     ) -> ArrayNParamsXNParams:
@@ -359,6 +367,7 @@ class FullRankNormal(Variational):
 
         return scipy.linalg.block_diag(mu_block, sigma_block)
 
+    @override
     def export_dict(self, variational_parameters: ArrayNParams) -> dict:
         """Create a dict of the distribution based on the given parameters.
 

--- a/src/queens/variational_distributions/full_rank_normal.py
+++ b/src/queens/variational_distributions/full_rank_normal.py
@@ -176,15 +176,6 @@ class FullRankNormal(Variational):
 
     @override
     def draw(self, variational_parameters: ArrayNParams, n_draws: NSamples) -> ArrayNSamplesXNDims:
-        """Draw *n_draw* samples from the variational distribution.
-
-        Args:
-            variational_parameters: Variational parameters
-            n_draws: Number of samples to draw
-
-        Returns:
-            Samples
-        """
         mean, _, cholesky = self.reconstruct_distribution_parameters_with_cholesky(
             variational_parameters
         )
@@ -193,15 +184,6 @@ class FullRankNormal(Variational):
 
     @override
     def logpdf(self, variational_parameters: ArrayNParams, x: ArrayNSamplesXNDims) -> ArrayNSamples:
-        """Log-PDF evaluated at the samples *x*.
-
-        Args:
-            variational_parameters: Variational parameters
-            x: Row-wise samples
-
-        Returns:
-            Log-PDF values
-        """
         mean, cov, cholesky = self.reconstruct_distribution_parameters_with_cholesky(
             variational_parameters
         )
@@ -238,17 +220,6 @@ class FullRankNormal(Variational):
     def grad_params_logpdf(
         self, variational_parameters: ArrayNParams, x: ArrayNSamplesXNDims
     ) -> ArrayNParamsXNSamples:
-        """Log-PDF gradient with respect to the variational parameters.
-
-        Evaluated at samples *x*. Also known as the score function.
-
-        Args:
-            variational_parameters: Variational parameters
-            x: Row-wise samples
-
-        Returns:
-            Column-wise scores
-        """
         mean, cov, cholesky = self.reconstruct_distribution_parameters_with_cholesky(
             variational_parameters
         )
@@ -369,13 +340,6 @@ class FullRankNormal(Variational):
 
     @override
     def export_dict(self, variational_parameters: ArrayNParams) -> dict:
-        """Create a dict of the distribution based on the given parameters.
-
-        Args:
-            variational_parameters: Variational parameters
-        Returns:
-            Dictionary containing distribution information
-        """
         mean, cov = self.reconstruct_distribution_parameters(variational_parameters)
         export_dict = {
             "type": "fullrank_Normal",

--- a/src/queens/variational_distributions/joint.py
+++ b/src/queens/variational_distributions/joint.py
@@ -307,14 +307,6 @@ class Joint(Variational, Generic[V]):
 
     @override
     def export_dict(self, variational_parameters: ArrayNParams) -> dict:
-        """Create a dict of the distribution based on the given parameters.
-
-        Args:
-            variational_parameters: Variational parameters
-
-        Returns:
-            Dictionary containing distribution information
-        """
         export_dict = {
             "type": "joint",
             "dimension": self.dimension,

--- a/src/queens/variational_distributions/joint.py
+++ b/src/queens/variational_distributions/joint.py
@@ -14,7 +14,7 @@
 #
 """Joint Variational Distribution."""
 
-from typing import Generic, Iterator, TypeAlias, TypeVar
+from typing import Generic, Iterator, TypeAlias, TypeVar, override
 
 import numpy as np
 import scipy
@@ -80,6 +80,7 @@ class Joint(Variational, Generic[V]):
                 f"dimensions of the subdistributions {np.sum(self.distributions_dimension)}"
             )
 
+    @override
     def initialize_variational_parameters(self, random: bool = False) -> ArrayNParams:
         r"""Initialize variational parameters.
 
@@ -100,6 +101,7 @@ class Joint(Variational, Generic[V]):
 
         return variational_parameters
 
+    @override
     def construct_variational_parameters(  # pylint: disable=arguments-differ
         self, distributions_parameters: list
     ) -> ArrayNParams:
@@ -140,6 +142,7 @@ class Joint(Variational, Generic[V]):
         )
         return variational_parameters_list
 
+    @override
     def reconstruct_distribution_parameters(
         self, variational_parameters: ArrayNParams
     ) -> list[list[tuple[list | np.ndarray]]]:
@@ -204,6 +207,7 @@ class Joint(Variational, Generic[V]):
             strict=True,
         )
 
+    @override
     def draw(self, variational_parameters: ArrayNParams, n_draws: NSamples) -> ArrayNSamplesXNDims:
         """Draw *n_draw* samples from the variational distribution.
 
@@ -221,6 +225,7 @@ class Joint(Variational, Generic[V]):
             sample_array.append(distribution.draw(parameters, n_draws))
         return np.column_stack(sample_array)
 
+    @override
     def logpdf(self, variational_parameters: ArrayNParams, x: ArrayNSamplesXNDims) -> ArrayNSamples:
         """Log-PDF evaluated using the variational parameters at samples *x*.
 
@@ -240,6 +245,7 @@ class Joint(Variational, Generic[V]):
             logpdf += distribution.logpdf(parameters, samples)
         return logpdf
 
+    @override
     def pdf(self, variational_parameters: ArrayNParams, x: ArrayNSamplesXNDims) -> ArrayNSamples:
         """Pdf evaluated using the variational parameters at given samples `x`.
 
@@ -253,14 +259,14 @@ class Joint(Variational, Generic[V]):
         pdf = np.exp(self.logpdf(variational_parameters, x))
         return pdf
 
+    @override
     def grad_params_logpdf(
         self, variational_parameters: ArrayNParams, x: ArrayNSamplesXNDims
     ) -> ArrayNParamsXNSamples:
-        """Log-PDF gradient w.r.t. the variational parameters.
+        """Log-PDF gradient with respect to the variational parameters.
 
-        Evaluated at samples *x*. Also known as the score function.
-        Is a general implementation using the score functions of
-        the components.
+        Evaluated at samples *x*. Also known as the score function. Is a general implementation
+        using the score functions of the components.
 
         Args:
             variational_parameters: Variational parameters
@@ -279,6 +285,7 @@ class Joint(Variational, Generic[V]):
 
         return np.row_stack(score)
 
+    @override
     def fisher_information_matrix(
         self, variational_parameters: ArrayNParams
     ) -> ArrayNParamsXNParams:
@@ -298,6 +305,7 @@ class Joint(Variational, Generic[V]):
 
         return scipy.linalg.block_diag(*fim)
 
+    @override
     def export_dict(self, variational_parameters: ArrayNParams) -> dict:
         """Create a dict of the distribution based on the given parameters.
 

--- a/src/queens/variational_distributions/joint.py
+++ b/src/queens/variational_distributions/joint.py
@@ -209,15 +209,6 @@ class Joint(Variational, Generic[V]):
 
     @override
     def draw(self, variational_parameters: ArrayNParams, n_draws: NSamples) -> ArrayNSamplesXNDims:
-        """Draw *n_draw* samples from the variational distribution.
-
-        Args:
-            variational_parameters: Variational parameters
-            n_draws: Number of samples to draw
-
-        Returns:
-            Samples
-        """
         sample_array = []
         for parameters, distribution in self._zip_variational_parameters_distributions(
             variational_parameters
@@ -227,15 +218,6 @@ class Joint(Variational, Generic[V]):
 
     @override
     def logpdf(self, variational_parameters: ArrayNParams, x: ArrayNSamplesXNDims) -> ArrayNSamples:
-        """Log-PDF evaluated using the variational parameters at samples *x*.
-
-        Args:
-            variational_parameters: Variational parameters
-            x: Row-wise samples
-
-        Returns:
-            Row vector of the Log-PDF values
-        """
         logpdf = np.zeros(x.shape[0], dtype=float)
         for (
             parameters,
@@ -247,15 +229,6 @@ class Joint(Variational, Generic[V]):
 
     @override
     def pdf(self, variational_parameters: ArrayNParams, x: ArrayNSamplesXNDims) -> ArrayNSamples:
-        """Pdf evaluated using the variational parameters at given samples `x`.
-
-        Args:
-            variational_parameters: Variational parameters
-            x: Row-wise samples
-
-        Returns:
-            Row vector of the PDF values
-        """
         pdf = np.exp(self.logpdf(variational_parameters, x))
         return pdf
 

--- a/src/queens/variational_distributions/mean_field_normal.py
+++ b/src/queens/variational_distributions/mean_field_normal.py
@@ -284,14 +284,6 @@ class MeanFieldNormal(Variational):
 
     @override
     def export_dict(self, variational_parameters: ArrayNParams) -> dict:
-        """Create a dict of the distribution based on the given parameters.
-
-        Args:
-            variational_parameters: Variational parameters
-
-        Returns:
-            Dictionary containing distribution information
-        """
         mean, cov = self.reconstruct_distribution_parameters(variational_parameters)
         sd = cov**0.5
         export_dict = {

--- a/src/queens/variational_distributions/mean_field_normal.py
+++ b/src/queens/variational_distributions/mean_field_normal.py
@@ -257,8 +257,8 @@ class MeanFieldNormal(Variational):
 
         Returns:
             Gradients of the log-PDF with respect to the sample *x*. The first dimension of the
-            array corresponds to the different samples. The second dimension to different
-            dimensions within one sample.
+                array corresponds to the different samples. The second dimension to different
+                dimensions within one sample.
         """
         mean, cov = self.reconstruct_distribution_parameters(variational_parameters)
         gradients_batch = -(sample_batch - mean.reshape(1, self.dimension)) / np.diag(cov).reshape(

--- a/src/queens/variational_distributions/mean_field_normal.py
+++ b/src/queens/variational_distributions/mean_field_normal.py
@@ -145,15 +145,6 @@ class MeanFieldNormal(Variational):
 
     @override
     def draw(self, variational_parameters: ArrayNParams, n_draws: NSamples) -> ArrayNSamplesXNDims:
-        """Draw *n_draw* samples from the variational distribution.
-
-        Args:
-            variational_parameters: Variational parameters
-            n_draws: Number of samples to draw
-
-        Returns:
-            Samples
-        """
         mean, cov = self.reconstruct_distribution_parameters(variational_parameters)
         samples = np.random.randn(n_draws, self.dimension) * np.sqrt(np.diag(cov)).reshape(
             1, -1
@@ -162,15 +153,6 @@ class MeanFieldNormal(Variational):
 
     @override
     def logpdf(self, variational_parameters: ArrayNParams, x: ArrayNSamplesXNDims) -> ArrayNSamples:
-        """Log-PDF evaluated using the variational parameters at samples `x`.
-
-        Args:
-            variational_parameters: Variational parameters
-            x: Row-wise samples
-
-        Returns:
-            Row vector of the Log-PDF values
-        """
         mean, cov = self.reconstruct_distribution_parameters(variational_parameters)
         mean_flat = mean.flatten()
         cov = np.diag(cov)
@@ -184,17 +166,6 @@ class MeanFieldNormal(Variational):
 
     @override
     def pdf(self, variational_parameters: ArrayNParams, x: ArrayNSamplesXNDims) -> ArrayNSamples:
-        """PDF of the variational distribution evaluated at samples *x*.
-
-        First computes the log-PDF, which is numerically more stable for exponential distributions.
-
-        Args:
-            variational_parameters: Variational parameters
-            x: Row-wise samples
-
-        Returns:
-            Row vector of the PDF values
-        """
         pdf = np.exp(self.logpdf(variational_parameters, x))
         return pdf
 
@@ -202,17 +173,6 @@ class MeanFieldNormal(Variational):
     def grad_params_logpdf(
         self, variational_parameters: ArrayNParams, x: ArrayNSamplesXNDims
     ) -> ArrayNParamsXNSamples:
-        """Log-PDF gradient with respect to the variational parameters.
-
-        Evaluated at samples *x*. Also known as the score function.
-
-        Args:
-            variational_parameters: Variational parameters
-            x: Row-wise samples
-
-        Returns:
-            Column-wise scores
-        """
         mean, cov = self.reconstruct_distribution_parameters(variational_parameters)
         mean_flat = mean.flatten()
         cov = np.diag(cov)

--- a/src/queens/variational_distributions/mean_field_normal.py
+++ b/src/queens/variational_distributions/mean_field_normal.py
@@ -145,15 +145,6 @@ class MeanFieldNormal(Variational):
 
     @override
     def draw(self, variational_parameters: ArrayNParams, n_draws: NSamples) -> ArrayNSamplesXNDims:
-        """Draw *n_draw* samples from the variational distribution.
-
-        Args:
-            variational_parameters: Variational parameters
-            n_draws: Number of samples to draw
-
-        Returns:
-            Samples
-        """
         mean, cov = self.reconstruct_distribution_parameters(variational_parameters)
         samples = np.random.randn(n_draws, self.dimension) * np.sqrt(np.diag(cov)).reshape(
             1, -1
@@ -162,15 +153,6 @@ class MeanFieldNormal(Variational):
 
     @override
     def logpdf(self, variational_parameters: ArrayNParams, x: ArrayNSamplesXNDims) -> ArrayNSamples:
-        """Log-PDF evaluated using the variational parameters at samples `x`.
-
-        Args:
-            variational_parameters: Variational parameters
-            x: Row-wise samples
-
-        Returns:
-            Row vector of the Log-PDF values
-        """
         mean, cov = self.reconstruct_distribution_parameters(variational_parameters)
         mean_flat = mean.flatten()
         cov = np.diag(cov)
@@ -184,17 +166,8 @@ class MeanFieldNormal(Variational):
 
     @override
     def pdf(self, variational_parameters: ArrayNParams, x: ArrayNSamplesXNDims) -> ArrayNSamples:
-        """PDF of the variational distribution evaluated at samples *x*.
-
-        First computes the log-PDF, which is numerically more stable for exponential distributions.
-
-        Args:
-            variational_parameters: Variational parameters
-            x: Row-wise samples
-
-        Returns:
-            Row vector of the PDF values
-        """
+        # First computes the log-PDF, which is numerically more stable
+        # for exponential distributions.
         pdf = np.exp(self.logpdf(variational_parameters, x))
         return pdf
 
@@ -202,17 +175,6 @@ class MeanFieldNormal(Variational):
     def grad_params_logpdf(
         self, variational_parameters: ArrayNParams, x: ArrayNSamplesXNDims
     ) -> ArrayNParamsXNSamples:
-        """Log-PDF gradient with respect to the variational parameters.
-
-        Evaluated at samples *x*. Also known as the score function.
-
-        Args:
-            variational_parameters: Variational parameters
-            x: Row-wise samples
-
-        Returns:
-            Column-wise scores
-        """
         mean, cov = self.reconstruct_distribution_parameters(variational_parameters)
         mean_flat = mean.flatten()
         cov = np.diag(cov)

--- a/src/queens/variational_distributions/mean_field_normal.py
+++ b/src/queens/variational_distributions/mean_field_normal.py
@@ -14,7 +14,7 @@
 #
 """Mean-Field Normal Variational Distribution."""
 
-from typing import cast
+from typing import cast, override
 
 import numpy as np
 
@@ -60,6 +60,7 @@ class MeanFieldNormal(Variational):
         """
         super().__init__(dimension, n_parameters=2 * dimension)
 
+    @override
     def initialize_variational_parameters(self, random: bool = False) -> ArrayNParams:
         r"""Initialize variational parameters.
 
@@ -87,6 +88,7 @@ class MeanFieldNormal(Variational):
 
         return variational_parameters
 
+    @override
     def construct_variational_parameters(  # pylint: disable=arguments-differ
         self, mean: ArrayNDimsX1 | ArrayNDims, covariance: ArrayNDimsXNDims
     ) -> ArrayNParams:
@@ -108,6 +110,7 @@ class MeanFieldNormal(Variational):
             )
         return variational_parameters
 
+    @override
     def reconstruct_distribution_parameters(
         self, variational_parameters: ArrayNParams
     ) -> tuple[ArrayNDimsX1, ArrayNDimsXNDims]:
@@ -140,6 +143,7 @@ class MeanFieldNormal(Variational):
         grad_reconstruct_params = np.hstack((grad_mean, grad_std))
         return grad_reconstruct_params
 
+    @override
     def draw(self, variational_parameters: ArrayNParams, n_draws: NSamples) -> ArrayNSamplesXNDims:
         """Draw *n_draw* samples from the variational distribution.
 
@@ -156,6 +160,7 @@ class MeanFieldNormal(Variational):
         ) + mean.reshape(1, -1)
         return samples
 
+    @override
     def logpdf(self, variational_parameters: ArrayNParams, x: ArrayNSamplesXNDims) -> ArrayNSamples:
         """Log-PDF evaluated using the variational parameters at samples `x`.
 
@@ -177,6 +182,7 @@ class MeanFieldNormal(Variational):
         )
         return logpdf.flatten()
 
+    @override
     def pdf(self, variational_parameters: ArrayNParams, x: ArrayNSamplesXNDims) -> ArrayNSamples:
         """PDF of the variational distribution evaluated at samples *x*.
 
@@ -192,10 +198,11 @@ class MeanFieldNormal(Variational):
         pdf = np.exp(self.logpdf(variational_parameters, x))
         return pdf
 
+    @override
     def grad_params_logpdf(
         self, variational_parameters: ArrayNParams, x: ArrayNSamplesXNDims
     ) -> ArrayNParamsXNSamples:
-        """Log-PDF gradient w.r.t. the variational parameters.
+        """Log-PDF gradient with respect to the variational parameters.
 
         Evaluated at samples *x*. Also known as the score function.
 
@@ -242,16 +249,16 @@ class MeanFieldNormal(Variational):
     def grad_sample_logpdf(
         self, variational_parameters: ArrayNParams, sample_batch: ArrayNSamplesXNDims
     ) -> ArrayNSamplesXNDims:
-        """Computes the gradient of the log-PDF w.r.t. to the sample *x*.
+        """Compute the gradient of the log-PDF with respect to the sample *x*.
 
         Args:
             variational_parameters: Variational parameters
             sample_batch: Row-wise samples
 
         Returns:
-            Gradients of the log-PDF w.r.t. the sample *x*. The first dimension of the array
-                corresponds to the different samples. The second dimension to different dimensions
-                within one sample.
+            Gradients of the log-PDF with respect to the sample *x*. The first dimension of the
+            array corresponds to the different samples. The second dimension to different
+            dimensions within one sample.
         """
         mean, cov = self.reconstruct_distribution_parameters(variational_parameters)
         gradients_batch = -(sample_batch - mean.reshape(1, self.dimension)) / np.diag(cov).reshape(
@@ -259,6 +266,7 @@ class MeanFieldNormal(Variational):
         )
         return gradients_batch
 
+    @override
     def fisher_information_matrix(
         self, variational_parameters: ArrayNParams
     ) -> ArrayNParamsXNParams:
@@ -274,6 +282,7 @@ class MeanFieldNormal(Variational):
         fisher_diag = np.hstack((fisher_diag, 2 * np.ones(self.dimension)))
         return np.diag(fisher_diag)
 
+    @override
     def export_dict(self, variational_parameters: ArrayNParams) -> dict:
         """Create a dict of the distribution based on the given parameters.
 

--- a/src/queens/variational_distributions/mixture_model.py
+++ b/src/queens/variational_distributions/mixture_model.py
@@ -14,7 +14,7 @@
 #
 """Mixture Model Variational Distribution."""
 
-from typing import Generic, Iterable, TypeAlias, TypeVar
+from typing import Generic, Iterable, TypeAlias, TypeVar, override
 
 import numpy as np
 
@@ -67,6 +67,7 @@ class MixtureModel(Variational, Generic[V]):
         self.n_components = n_components
         self.base_distribution = base_distribution
 
+    @override
     def initialize_variational_parameters(self, random: bool = False) -> ArrayNParams:
         r"""Initialize variational parameters.
 
@@ -103,6 +104,7 @@ class MixtureModel(Variational, Generic[V]):
 
         return np.concatenate([variational_parameters_components, variational_parameters_weights])
 
+    @override
     def construct_variational_parameters(  # pylint: disable=arguments-differ
         self, parameters_per_component: list[Iterable[np.ndarray]], weights: ArrayNComponents
     ) -> ArrayNParams:
@@ -151,6 +153,7 @@ class MixtureModel(Variational, Generic[V]):
         weights = weights / np.sum(weights)
         return variational_parameters_list, weights
 
+    @override
     def reconstruct_distribution_parameters(
         self, variational_parameters: ArrayNParams
     ) -> tuple[list[tuple[list | np.ndarray]], ArrayNComponents]:
@@ -180,6 +183,7 @@ class MixtureModel(Variational, Generic[V]):
         weights = weights / np.sum(weights)
         return distribution_parameters_list, weights
 
+    @override
     def draw(self, variational_parameters: ArrayNParams, n_draws: NSamples) -> ArrayNSamplesXNDims:
         """Draw *n_draw* samples from the variational distribution.
 
@@ -207,6 +211,7 @@ class MixtureModel(Variational, Generic[V]):
         samples = np.concatenate(samples_lst, axis=0)
         return samples
 
+    @override
     def logpdf(self, variational_parameters: ArrayNParams, x: ArrayNSamplesXNDims) -> ArrayNSamples:
         """Log-PDF evaluated using the variational parameters at samples *x*.
 
@@ -239,6 +244,7 @@ class MixtureModel(Variational, Generic[V]):
         logpdf = np.log(logpdf) + max_logpdf
         return logpdf
 
+    @override
     def pdf(self, variational_parameters: ArrayNParams, x: ArrayNSamplesXNDims) -> ArrayNSamples:
         """Pdf evaluated using the variational parameters at given samples `x`.
 
@@ -252,14 +258,14 @@ class MixtureModel(Variational, Generic[V]):
         pdf = np.exp(self.logpdf(variational_parameters, x))
         return pdf
 
+    @override
     def grad_params_logpdf(
         self, variational_parameters: ArrayNParams, x: ArrayNSamplesXNDims
     ) -> ArrayNParamsXNSamples:
-        """Log-PDF gradient w.r.t. the variational parameters.
+        """Log-PDF gradient with respect to the variational parameters.
 
-        Evaluated at samples *x*. Also known as the score function.
-        Is a general implementation using the score functions of
-        the components.
+        Evaluated at samples *x*. Also known as the score function. Is a general implementation
+        using the score functions of the components.
 
         Args:
             variational_parameters: Variational parameters
@@ -293,6 +299,7 @@ class MixtureModel(Variational, Generic[V]):
         score = np.vstack((np.concatenate(component_block, axis=0), weights_block))
         return score
 
+    @override
     def fisher_information_matrix(
         self, variational_parameters: ArrayNParams, n_samples: int = 10000
     ) -> ArrayNParamsXNParams:
@@ -314,6 +321,7 @@ class MixtureModel(Variational, Generic[V]):
         fim = fim / n_samples
         return fim
 
+    @override
     def export_dict(self, variational_parameters: ArrayNParams) -> dict:
         """Create a dict of the distribution based on the given parameters.
 

--- a/src/queens/variational_distributions/mixture_model.py
+++ b/src/queens/variational_distributions/mixture_model.py
@@ -246,15 +246,6 @@ class MixtureModel(Variational, Generic[V]):
 
     @override
     def pdf(self, variational_parameters: ArrayNParams, x: ArrayNSamplesXNDims) -> ArrayNSamples:
-        """Pdf evaluated using the variational parameters at given samples `x`.
-
-        Args:
-            variational_parameters: Variational parameters
-            x: Row-wise samples
-
-        Returns:
-            Row vector of the PDF values
-        """
         pdf = np.exp(self.logpdf(variational_parameters, x))
         return pdf
 
@@ -262,18 +253,6 @@ class MixtureModel(Variational, Generic[V]):
     def grad_params_logpdf(
         self, variational_parameters: ArrayNParams, x: ArrayNSamplesXNDims
     ) -> ArrayNParamsXNSamples:
-        """Log-PDF gradient with respect to the variational parameters.
-
-        Evaluated at samples *x*. Also known as the score function. Is a general implementation
-        using the score functions of the components.
-
-        Args:
-            variational_parameters: Variational parameters
-            x: Row-wise samples
-
-        Returns:
-            Column-wise scores
-        """
         parameters, weights = self._construct_component_variational_parameters(
             variational_parameters
         )

--- a/src/queens/variational_distributions/mixture_model.py
+++ b/src/queens/variational_distributions/mixture_model.py
@@ -323,14 +323,6 @@ class MixtureModel(Variational, Generic[V]):
 
     @override
     def export_dict(self, variational_parameters: ArrayNParams) -> dict:
-        """Create a dict of the distribution based on the given parameters.
-
-        Args:
-            variational_parameters: Variational parameters
-
-        Returns:
-            Dictionary containing distribution information
-        """
         parameters, weights = self._construct_component_variational_parameters(
             variational_parameters
         )

--- a/src/queens/variational_distributions/particle.py
+++ b/src/queens/variational_distributions/particle.py
@@ -115,43 +115,16 @@ class Particle(Variational):
 
     @override
     def draw(self, variational_parameters: ArrayNParams, n_draws: NSamples) -> ArrayNSamplesXNDims:
-        """Draw *n_draws* samples from distribution.
-
-        Args:
-            variational_parameters: Variational parameters of the distribution
-            n_draws: Number of samples
-
-        Returns:
-            Samples
-        """
         self.reconstruct_distribution_parameters(variational_parameters)
         return self.particles_obj.draw(n_draws)
 
     @override
     def logpdf(self, variational_parameters: ArrayNParams, x: ArrayNSamplesXNDims) -> ArrayNSamples:
-        """Evaluate the natural logarithm of the PDF.
-
-        Args:
-            variational_parameters: Variational parameters of the distribution
-            x: Locations at which to evaluate the distribution
-
-        Returns:
-            Log-PDF values at the locations x
-        """
         self.reconstruct_distribution_parameters(variational_parameters)
         return self.particles_obj.logpdf(x)
 
     @override
     def pdf(self, variational_parameters: ArrayNParams, x: ArrayNSamplesXNDims) -> ArrayNSamples:
-        """Evaluate the probability density function (PDF).
-
-        Args:
-            variational_parameters: Variational parameters of the distribution
-            x: Locations at which to evaluate the distribution
-
-        Returns:
-            Row vector of the PDF values
-        """
         self.reconstruct_distribution_parameters(variational_parameters)
         return self.particles_obj.pdf(x)
 

--- a/src/queens/variational_distributions/particle.py
+++ b/src/queens/variational_distributions/particle.py
@@ -15,6 +15,7 @@
 """Particle Variational Distribution."""
 
 from collections.abc import Sequence, Sized
+from typing import override
 
 import numpy as np
 
@@ -50,6 +51,7 @@ class Particle(Variational):
         self.particles_obj = ParticleDistribution(np.ones(len(sample_space)), sample_space)
         super().__init__(self.particles_obj.dimension, n_parameters=len(sample_space))
 
+    @override
     def construct_variational_parameters(  # pylint: disable=arguments-differ
         self, probabilities: ArrayNParams, sample_space: np.ndarray | Sequence[Sized]
     ) -> ArrayNParams:
@@ -66,6 +68,7 @@ class Particle(Variational):
         variational_parameters = np.log(probabilities).flatten()
         return variational_parameters
 
+    @override
     def initialize_variational_parameters(self, random: bool = False) -> ArrayNParams:
         r"""Initialize variational parameters.
 
@@ -92,6 +95,7 @@ class Particle(Variational):
 
         return variational_parameters
 
+    @override
     def reconstruct_distribution_parameters(
         self, variational_parameters: ArrayNParams
     ) -> tuple[ArrayNParams, np.ndarray]:
@@ -109,6 +113,7 @@ class Particle(Variational):
         self.particles_obj = ParticleDistribution(probabilities, self.particles_obj.sample_space)
         return probabilities, self.particles_obj.sample_space
 
+    @override
     def draw(self, variational_parameters: ArrayNParams, n_draws: NSamples) -> ArrayNSamplesXNDims:
         """Draw *n_draws* samples from distribution.
 
@@ -122,6 +127,7 @@ class Particle(Variational):
         self.reconstruct_distribution_parameters(variational_parameters)
         return self.particles_obj.draw(n_draws)
 
+    @override
     def logpdf(self, variational_parameters: ArrayNParams, x: ArrayNSamplesXNDims) -> ArrayNSamples:
         """Evaluate the natural logarithm of the PDF.
 
@@ -135,6 +141,7 @@ class Particle(Variational):
         self.reconstruct_distribution_parameters(variational_parameters)
         return self.particles_obj.logpdf(x)
 
+    @override
     def pdf(self, variational_parameters: ArrayNParams, x: ArrayNSamplesXNDims) -> ArrayNSamples:
         """Evaluate the probability density function (PDF).
 
@@ -148,10 +155,11 @@ class Particle(Variational):
         self.reconstruct_distribution_parameters(variational_parameters)
         return self.particles_obj.pdf(x)
 
+    @override
     def grad_params_logpdf(
         self, variational_parameters: ArrayNParams, x: ArrayNSamplesXNDims
     ) -> ArrayNParamsXNSamples:
-        r"""Log-PDF gradient w.r.t. the variational parameters.
+        r"""Log-PDF gradient with respect to the variational parameters.
 
         Evaluated at samples  *x*. Also known as the score function.
 
@@ -181,6 +189,7 @@ class Particle(Variational):
         # Get the samples
         return sample_scores[index].T
 
+    @override
     def fisher_information_matrix(
         self, variational_parameters: ArrayNParams
     ) -> ArrayNParamsXNParams:
@@ -199,6 +208,7 @@ class Particle(Variational):
         fim = np.diag(probabilities) - np.outer(probabilities, probabilities)
         return fim
 
+    @override
     def export_dict(self, variational_parameters: ArrayNParams) -> dict:
         """Create a dict of the distribution based on the given parameters.
 

--- a/src/queens/variational_distributions/particle.py
+++ b/src/queens/variational_distributions/particle.py
@@ -210,14 +210,6 @@ class Particle(Variational):
 
     @override
     def export_dict(self, variational_parameters: ArrayNParams) -> dict:
-        """Create a dict of the distribution based on the given parameters.
-
-        Args:
-            variational_parameters: Variational parameters
-
-        Returns:
-            Dictionary containing distribution information
-        """
         self.reconstruct_distribution_parameters(variational_parameters)
         export_dict = {
             "type": type(self),

--- a/tutorials/4_quantifying_uncertainty_due_to_heterogeneous_material_fields/random_field.py
+++ b/tutorials/4_quantifying_uncertainty_due_to_heterogeneous_material_fields/random_field.py
@@ -13,7 +13,9 @@
 # see <https://www.gnu.org/licenses/>.
 #
 """CustomRandomField module for tutorial 4."""
+
 from collections.abc import Callable
+from typing import override
 
 import numpy as np
 
@@ -45,6 +47,7 @@ class CustomRandomField(RandomField):
         self.expansion = expansion
         self.coordinates = coords["coords"]
 
+    @override
     def draw(self, num_samples: int) -> np.ndarray:
         """Draw ``num_samples`` samples of the latent space.
 
@@ -53,6 +56,7 @@ class CustomRandomField(RandomField):
         """
         return self.latent_distribution.draw(num_samples)
 
+    @override
     def expanded_representation(self, samples: np.ndarray) -> np.ndarray:
         """Expand the random field realization.
 
@@ -69,6 +73,7 @@ class CustomRandomField(RandomField):
 
         return np.array(expansions)
 
+    @override
     def logpdf(self, samples: np.ndarray) -> np.ndarray:
         """Get joint logpdf of latent space.
 
@@ -77,6 +82,7 @@ class CustomRandomField(RandomField):
         """
         return self.latent_distribution.logpdf(samples)
 
+    @override
     def grad_logpdf(self, samples: np.ndarray) -> np.ndarray:
         """Get gradient of joint logpdf of latent space.
 
@@ -85,6 +91,7 @@ class CustomRandomField(RandomField):
         """
         raise NotImplementedError()
 
+    @override
     def latent_gradient(self, upstream_gradient: np.ndarray) -> np.ndarray:
         """Gradient of the field with respect to the latent variables."""
         raise NotImplementedError()

--- a/tutorials/4_quantifying_uncertainty_due_to_heterogeneous_material_fields/random_field.py
+++ b/tutorials/4_quantifying_uncertainty_due_to_heterogeneous_material_fields/random_field.py
@@ -49,20 +49,10 @@ class CustomRandomField(RandomField):
 
     @override
     def draw(self, num_samples: int) -> np.ndarray:
-        """Draw ``num_samples`` samples of the latent space.
-
-        Args:
-            num_samples (int): Batch size of samples to draw
-        """
         return self.latent_distribution.draw(num_samples)
 
     @override
     def expanded_representation(self, samples: np.ndarray) -> np.ndarray:
-        """Expand the random field realization.
-
-        Args:
-            samples (np.array): Latent space variables to be expanded into a random field
-        """
         if samples.ndim == 1:
             return self.expansion(samples, self.coordinates)
 
@@ -75,23 +65,12 @@ class CustomRandomField(RandomField):
 
     @override
     def logpdf(self, samples: np.ndarray) -> np.ndarray:
-        """Get joint logpdf of latent space.
-
-        Args:
-            samples (np.array): Sample to evaluate logpdf
-        """
         return self.latent_distribution.logpdf(samples)
 
     @override
     def grad_logpdf(self, samples: np.ndarray) -> np.ndarray:
-        """Get gradient of joint logpdf of latent space.
-
-        Args:
-            samples (np.array): Sample to evaluate gradient of logpdf
-        """
         raise NotImplementedError()
 
     @override
     def latent_gradient(self, upstream_gradient: np.ndarray) -> np.ndarray:
-        """Gradient of the field with respect to the latent variables."""
         raise NotImplementedError()


### PR DESCRIPTION
## Description and Context:<br> What and Why?
<!--
Provide a brief and concise description of your proposed change.
In particular: Why is this change required? What problem does it solve? Is this a breaking change?
-->

While working on #318, I played around with the `@override` decorator. I find it useful for 3 reasons:
1. when scanning over the code, it makes it clear which methods are base class implementations and hence helps understanding their purpose.
2. pylance directly flags any override misuses, like adding variables or changing their types.
3. It allows not writing another redundant docstring for the inherited method (but you still can if you want to)

This has only the required change for the mypy configuration so far (so pipeline failure is expected). If people like this change, I can add override decorators to all inherited methods that are currently type-checked.  

## Related Issues and Pull Requests
<!--
If applicable: how is this pull request related to other open issues or pull requests?
-->
* Closes
* Related to

## Interested Parties
<!--
If there's anyone you think should be looped in on this pull request,
feel free to @mention them here!
-->

> Note: More information on the merge request procedure in QUEENS can be found in the [*Submit a pull request*](../CONTRIBUTING.md#5-submit-a-pull-request) section in the [CONTRIBUTING.md](../CONTRIBUTING.md) file.
