### PR TITLE
ci: update dependencies every 3 months

### DIFF
--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -3,7 +3,7 @@ name: Update Dependencies
 "on":
   workflow_dispatch:
   schedule:
-    - cron: "0 5 1 * *"
+    - cron: "0 5 1 */3 *"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description and Context:<br> What and Why?
<!--
Provide a brief and concise description of your proposed change.
In particular: Why is this change required? What problem does it solve? Is this a breaking change?
-->
To reduce the time we need to spend on making our codebase comply with new dependencies, I suggest running the update-dependencies pipeline only every 3 months instead of every month.

This time interval is up for discussion, I am open to different suggestions :)

## Related Issues and Pull Requests
<!--
If applicable: how is this pull request related to other open issues or pull requests?
-->
* Closes
* Related to

## Interested Parties
<!--
If there's anyone you think should be looped in on this pull request,
feel free to @mention them here!
-->

> Note: More information on the merge request procedure in QUEENS can be found in the [*Submit a pull request*](../CONTRIBUTING.md#5-submit-a-pull-request) section in the [CONTRIBUTING.md](../CONTRIBUTING.md) file.
