### PR TITLE
Add workflow to enforce 24-hour wait on PRs

### DIFF
--- a/.github/workflows/pull_request_age_check.yml
+++ b/.github/workflows/pull_request_age_check.yml
@@ -1,0 +1,73 @@
+name: Check pull request age
+"on":
+  schedule:
+    - cron: "49 0 * * *"
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+
+jobs:
+  check_pull_request_age:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check pull request age
+        # Pull request events contain the PR creation timestamp, so this step
+        # performs the actual age check.
+        if: github.event_name == 'pull_request'
+        env:
+          PR_CREATED_AT: ${{ github.event.pull_request.created_at }}
+        run: |
+          if [ -z "${PR_CREATED_AT}" ]; then
+            echo "This check must run on a pull request."
+            exit 1
+          fi
+
+          pr_created_at="$(date -u -d "${PR_CREATED_AT}" +%s)"
+          now="$(date -u +%s)"
+
+          if [ $((now - pr_created_at)) -lt 86400 ]; then
+            echo "This pull request must be open for 24 hours before this check passes."
+            exit 1
+          fi
+
+          echo "This pull request has been open for at least 24 hours."
+
+      - name: Re-run failed age checks for open pull requests
+        # Scheduled workflows do not run on a single PR. This step loops over PRs and
+        # reruns any failed age checks.
+        if: github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          WORKFLOW_FILE: pull_request_age_check.yml
+        run: |
+          gh pr list \
+            --json number,headRefOid \
+            --jq '.[] | "\(.number) \(.headRefOid)"' |
+          # Loop over PRs and their head commits
+          while read -r pr_number head_sha; do
+            # Look up the latest failed age-check run on the PR's current
+            # head commit.
+            run_id="$(
+              gh run list \
+                --workflow "${WORKFLOW_FILE}" \
+                --event pull_request \
+                --commit "${head_sha}" \
+                --status failure \
+                --limit 1 \
+                --json databaseId \
+                --jq '.[0].databaseId'
+            )"
+
+            if [ -z "${run_id}" ]; then
+              echo "No failed age-check run found for pull request #${pr_number}."
+              continue
+            fi
+
+            echo "Re-running age check for pull request #${pr_number}."
+            gh run rerun "${run_id}"
+          done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,8 +139,4 @@ your source directory. For further information, see our [testing README.md](test
 #### 5. Submit a pull request
 Please use the available pull request template and fill out all sections of the template.
 When you have submitted a pull request and the CI pipeline passes, it will be reviewed.
-Once your pull request is approved, there is a 24h waiting time (business days only) until the branch is merged into the
-main branch by the QUEENS maintainers. This ensures that the community has a chance to have a final look over the changes.
-This rule can be circumvented if and only if:
-- All the active maintainers approve the pull request.
-- The pull request is labeled as a quickfix by one of the maintainers and approved. Examples for this are one-liners, typos or urgent fixes that are time-critical.
+At least two approving reviews by QUEENS developers are required to merge a pull request. Additionally, we enforce that a pull request must have been open for at least 24 hours before it can be merged.


### PR DESCRIPTION
## Description and Context:<br> What and Why?
<!--
Provide a brief and concise description of your proposed change.
In particular, Why is this change required? What problem does it solve? Is this a breaking change?
-->

As discussed in https://github.com/queens-py/queens-meetings/issues/39, this adds a workflow that passes only if the PR has been open for at least 24 hours. Failed age checks are re-run automatically every night for open PRs

I tried to keep this simple, so there are some limitations:
- Only the first opening counts. I do not account for reopened PRs or PRs that have been in draft mode.
- ~If the last check was before the 24 hours time, the corresponding test needs to be re-run manually. That's because scheduled workflows dont run on PRs. The alternative would be to run on main and then loop over all open PRs and use custom statuses, which I think is over-engineering here.~

After merging this, a @queens-py/maintainers would need to adapt the branch protection rules to include this check.

## Related Issues and Pull Requests
<!--
If applicable: how is this pull request related to other open issues or pull requests?
-->
* Closes
* Related to

## Interested Parties
<!--
If there's anyone you think should be looped in on this pull request,
feel free to @mention them here!
-->

> Note: More information on the merge request procedure in QUEENS can be found in the [*Submit a pull request*](../CONTRIBUTING.md#5-submit-a-pull-request) section in the [CONTRIBUTING.md](../CONTRIBUTING.md) file.
