### PR TITLE
ci: introduce checking whether private methods have docstrings

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -230,7 +230,7 @@ name-group=
 
 # Regular expression which should only match function or class names that do
 # not require a docstring.
-no-docstring-rgx=__getattr__
+no-docstring-rgx=^$
 
 # Regular expression matching correct parameter specification variable names.
 # If left empty, parameter specification variable names will be checked with

--- a/.pylintrc
+++ b/.pylintrc
@@ -230,7 +230,7 @@ name-group=
 
 # Regular expression which should only match function or class names that do
 # not require a docstring.
-no-docstring-rgx=^_
+no-docstring-rgx=__getattr__
 
 # Regular expression matching correct parameter specification variable names.
 # If left empty, parameter specification variable names will be checked with

--- a/src/queens/data_processors/__init__.py
+++ b/src/queens/data_processors/__init__.py
@@ -32,4 +32,12 @@ class_module_map = extract_type_checking_imports(__file__)
 
 
 def __getattr__(name):
+    """Lazily import a data processor class on first attribute access.
+
+    Args:
+        name: Name of the class to import.
+
+    Returns:
+        Imported class.
+    """
     return import_class_from_class_module_map(name, class_module_map, __name__)

--- a/src/queens/distributions/__init__.py
+++ b/src/queens/distributions/__init__.py
@@ -44,4 +44,12 @@ class_module_map = extract_type_checking_imports(__file__)
 
 
 def __getattr__(name: str) -> type[Distribution]:
+    """Lazily import a distribution class on first attribute access.
+
+    Args:
+        name: Name of the class to import.
+
+    Returns:
+        Imported class.
+    """
     return import_class_from_class_module_map(name, class_module_map, __name__)

--- a/src/queens/drivers/__init__.py
+++ b/src/queens/drivers/__init__.py
@@ -32,4 +32,12 @@ class_module_map = extract_type_checking_imports(__file__)
 
 
 def __getattr__(name):
+    """Lazily import a driver class on first attribute access.
+
+    Args:
+        name: Name of the class to import.
+
+    Returns:
+        Imported class.
+    """
     return import_class_from_class_module_map(name, class_module_map, __name__)

--- a/src/queens/iterators/__init__.py
+++ b/src/queens/iterators/__init__.py
@@ -53,4 +53,12 @@ class_module_map = extract_type_checking_imports(__file__)
 
 
 def __getattr__(name):
+    """Lazily import an iterator class on first attribute access.
+
+    Args:
+        name: Name of the class to import.
+
+    Returns:
+        Imported class.
+    """
     return import_class_from_class_module_map(name, class_module_map, __name__)

--- a/src/queens/models/__init__.py
+++ b/src/queens/models/__init__.py
@@ -44,4 +44,12 @@ class_module_map = extract_type_checking_imports(__file__)
 
 
 def __getattr__(name):
+    """Lazily import a model class on first attribute access.
+
+    Args:
+        name: Name of the class to import.
+
+    Returns:
+        Imported class.
+    """
     return import_class_from_class_module_map(name, class_module_map, __name__)

--- a/src/queens/parameters/random_fields/__init__.py
+++ b/src/queens/parameters/random_fields/__init__.py
@@ -34,4 +34,12 @@ class_module_map = extract_type_checking_imports(__file__)
 
 
 def __getattr__(name: str) -> type[RandomField]:
+    """Lazily import a random field class on first attribute access.
+
+    Args:
+        name: Name of the class to import.
+
+    Returns:
+        Imported class.
+    """
     return import_class_from_class_module_map(name, class_module_map, __name__)

--- a/src/queens/schedulers/__init__.py
+++ b/src/queens/schedulers/__init__.py
@@ -34,4 +34,12 @@ class_module_map = extract_type_checking_imports(__file__)
 
 
 def __getattr__(name):
+    """Lazily import a scheduler class on first attribute access.
+
+    Args:
+        name: Name of the class to import.
+
+    Returns:
+        Imported class.
+    """
     return import_class_from_class_module_map(name, class_module_map, __name__)

--- a/src/queens/stochastic_optimizers/__init__.py
+++ b/src/queens/stochastic_optimizers/__init__.py
@@ -32,4 +32,12 @@ class_module_map = extract_type_checking_imports(__file__)
 
 
 def __getattr__(name):
+    """Lazily import a stochastic optimizer class on first attribute access.
+
+    Args:
+        name: Name of the class to import.
+
+    Returns:
+        Imported class.
+    """
     return import_class_from_class_module_map(name, class_module_map, __name__)

--- a/src/queens/variational_distributions/__init__.py
+++ b/src/queens/variational_distributions/__init__.py
@@ -35,4 +35,14 @@ class_module_map = extract_type_checking_imports(__file__)
 
 
 def __getattr__(name: str) -> type[Variational]:
+    """Lazily import a variational distribution class.
+
+    Allows importing it on first attribute access.
+
+    Args:
+        name: Name of the class to import.
+
+    Returns:
+        Imported class.
+    """
     return import_class_from_class_module_map(name, class_module_map, __name__)


### PR DESCRIPTION
## Description and Context:<br> What and Why?
<!--
Provide a brief and concise description of your proposed change.
In particular: Why is this change required? What problem does it solve? Is this a breaking change?
-->
This PR introduces checking whether private methods (which were previously excluded) do actually have a docstring.

It should be noted that this pylint feature does not actually check whether the `Args:` and `Returns:` sections of the docstring match the function signature. Such an additional check is feasible via pylint's docparams extension, but requires refactoring large parts of the codebase, since many of the current docstrings are flagged.

## Related Issues and Pull Requests
<!--
If applicable: how is this pull request related to other open issues or pull requests?
-->
* Closes
* Related to

## Interested Parties
<!--
If there's anyone you think should be looped in on this pull request,
feel free to @mention them here!
-->

> Note: More information on the merge request procedure in QUEENS can be found in the [*Submit a pull request*](../CONTRIBUTING.md#5-submit-a-pull-request) section in the [CONTRIBUTING.md](../CONTRIBUTING.md) file.
