### PR TITLE
ci: allow only one automatic depdencies update PR at a time

### DIFF
--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -9,8 +9,73 @@ permissions:
   contents: read
 
 jobs:
+  check-existing-pr:
+    name: Check for open update PR
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    outputs:
+      exists: ${{ steps.check.outputs.exists }}
+    steps:
+      - name: Check for an open update-dependencies PR
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          pr_json="$(
+            gh pr list \
+              --repo "${{ github.repository }}" \
+              --base main \
+              --head update-dependencies \
+              --state open \
+              --json number,url \
+              --jq '.[0] // empty'
+          )"
+
+          if [ -z "${pr_json}" ]; then
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          pr_number="$(echo "${pr_json}" | jq -r '.number')"
+          pr_url="$(echo "${pr_json}" | jq -r '.url')"
+          echo "exists=true" >> "$GITHUB_OUTPUT"
+          echo "::notice title=Update Dependencies::PR #${pr_number} (${pr_url}) is still open." \
+              "Skipping this run to avoid overwriting in-progress fixes " \
+              "— please merge or close it first."
+          {
+            echo "### Update Dependencies skipped"
+            echo "PR [#${pr_number}](${pr_url}) from a previous run is still open."
+            echo "Merge or close it so the next scheduled run can proceed."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          marker="<!-- update-dependencies-stale-pr-notice -->"
+          existing_comment="$(
+            gh api "repos/${{ github.repository }}/issues/${pr_number}/comments" \
+              --paginate \
+              --jq "[.[] | select(.body | contains(\"${marker}\"))] | length"
+          )"
+
+          if [ "${existing_comment}" = "0" ]; then
+            {
+              echo "${marker}"
+              echo "This month's scheduled dependency update was skipped " \
+                "because this PR is still open."
+              echo "Merge or close this PR to let the next run proceed."
+              echo "Once resolved, you can manually re-run the workflow from the Actions tab" \
+                "(or \`gh workflow run update_dependencies.yml\`) instead of waiting for" \
+                "next month's schedule."
+            } > pr_comment.md
+
+            gh pr comment "${pr_number}" \
+              --repo "${{ github.repository }}" \
+              --body-file pr_comment.md
+          fi
+
   update-pixi:
     name: Update Dependencies
+    needs: check-existing-pr
+    if: needs.check-existing-pr.outputs.exists != 'true'
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
## Description and Context:<br> What and Why?
<!--
Provide a brief and concise description of your proposed change.
In particular: Why is this change required? What problem does it solve? Is this a breaking change?
-->
### Guard against overwriting in-progress fixes on the update-dependencies branch

**What changed**

- Added a `check-existing-pr` job that runs before the actual dependency update. It checks whether a PR from `update-dependencies` → `main` is still open.
- If one is open, the run stops there: it leaves a `::notice::` annotation and job summary, posts an explanatory comment on the stale PR (idempotent via a hidden marker, so it won't repost on every run), and skips the `update-pixi` job entirely (`needs` + `if` gate).
- If no PR is open, `update-pixi` runs exactly as before — same branch name, same app-token auth, same Pixi update logic.

**Why**

`peter-evans/create-pull-request` doesn't append commits to `update-dependencies` — every run resets the branch to a freshly rebuilt tree and force-pushes (`--force-with-lease`). That's fine when the previous update was merged, but when a monthly update PR was still open with manual fixes in progress, the next scheduled run silently wiped those commits.

This guard keeps the single fixed branch/PR model (no branch-name sprawl) but makes the workflow idempotent with respect to unfinished PRs: it never touches the branch while a PR is still open, and it makes that fact visible on the PR itself instead of only in Actions logs. The PR comment also points out that the workflow can be re-triggered manually (`workflow_dispatch`) once the PR is resolved, rather than waiting for next month's cron.

Suffixing the branch/PR name per run was considered but rejected: since nothing would ever close or supersede a prior unfinished PR, each unresolved monthly run would leave its predecessor behind and open a new one alongside it, turning a one-off "unfinished update got overwritten" problem into an ever-growing backlog of stale, mutually-conflicting "update dependencies" PRs that nobody is forced to reconcile. The guard job avoids that by refusing to produce a new PR while the previous one is still open, keeping the backlog capped at one actionable item instead of accumulating one per cycle.

## Related Issues and Pull Requests
<!--
If applicable: how is this pull request related to other open issues or pull requests?
-->
* Closes
* Related to

## Interested Parties
<!--
If there's anyone you think should be looped in on this pull request,
feel free to @mention them here!
-->

> Note: More information on the merge request procedure in QUEENS can be found in the [*Submit a pull request*](../CONTRIBUTING.md#5-submit-a-pull-request) section in the [CONTRIBUTING.md](../CONTRIBUTING.md) file.
