### PR TITLE
ci: make the update-dependencies PR title conventional commit conform

### DIFF
--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -110,7 +110,7 @@ jobs:
         with:
           token: ${{ steps.update_dependencies_token.outputs.token }}
           commit-message: "build: update dependencies"
-          title: Update dependencies
+          title: "build: update dependencies"
           body-path: pixi_update.md
           branch: update-dependencies
           base: main


### PR DESCRIPTION
## Description and Context:<br> What and Why?
<!--
Provide a brief and concise description of your proposed change.
In particular: Why is this change required? What problem does it solve? Is this a breaking change?
-->
Since Github uses a PR's title as the default commit message when squashing and merging a PR, I suggest adapting the title of the update-dependencies PR such that it automatically conforms to our conventional commits standard. This way, we (and particularly I 😇) will avoid a failing pipeline if we forget to adjust the commit message.

What do you think?

## Related Issues and Pull Requests
<!--
If applicable: how is this pull request related to other open issues or pull requests?
-->
* Closes
* Related to

## Interested Parties
<!--
If there's anyone you think should be looped in on this pull request,
feel free to @mention them here!
-->

> Note: More information on the merge request procedure in QUEENS can be found in the [*Submit a pull request*](../CONTRIBUTING.md#5-submit-a-pull-request) section in the [CONTRIBUTING.md](../CONTRIBUTING.md) file.
