### PR TITLE
refactor: add jobs that ensure all tests and Pypi build checks pass

### DIFF
--- a/.github/workflows/check_pull_request_age.yml
+++ b/.github/workflows/check_pull_request_age.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   check_pull_request_age:
+    name: Check pull request is at least 24 hours old
     runs-on: ubuntu-latest
     steps:
       - name: Check pull request age

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,4 +1,4 @@
-name: Build documentation
+name: Documentation
 
 "on":
   pull_request:

--- a/.github/workflows/local_testsuite.yml
+++ b/.github/workflows/local_testsuite.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   run_tests_core:
-    name: core tests (${{ matrix.os }})
+    name: Run core tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -44,7 +44,7 @@ jobs:
           markers: "unit_tests or integration_tests"
 
   run_tests_tutorials:
-    name: tutorial tests (${{ matrix.os }})
+    name: Run tutorial tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -70,7 +70,7 @@ jobs:
           markers: tutorial_tests
 
   run_tests_fourc:
-    name: 4C integration tests (ubuntu-latest)
+    name: Run 4C integration tests (ubuntu-latest)
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/4c-multiphysics/4c-minimal:main
@@ -96,7 +96,7 @@ jobs:
           markers: integration_tests_fourc
 
   run_tests_tutorials_fourc:
-    name: 4C tutorial tests (ubuntu-latest)
+    name: Run 4C tutorial tests (ubuntu-latest)
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/4c-multiphysics/4c-minimal:main
@@ -122,7 +122,7 @@ jobs:
           markers: tutorial_tests_fourc
 
   run_cluster_local_tests:
-    name: local cluster scheduler
+    name: Run local cluster scheduler tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -141,7 +141,7 @@ jobs:
               pytest -m cluster_local tests/integration_tests/cluster_local/ -v
 
   report_test_results:
-    name: report test results
+    name: Report test results
     if: always()
     runs-on: ubuntu-latest
     needs:
@@ -224,3 +224,19 @@ jobs:
           name: html-coverage-report
           path: html_coverage_report/
           retention-days: 7
+
+  ensure_all_tests_pass:
+    name: Ensure all tests pass
+    needs:
+      - run_tests_core
+      - run_tests_tutorials
+      - run_tests_fourc
+      - run_tests_tutorials_fourc
+      - run_cluster_local_tests
+    runs-on: ubuntu-latest
+    if: always() && github.ref != 'refs/heads/main'
+    steps:
+      - name: Check for successful tests
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/test_pypi_build.yml
+++ b/.github/workflows/test_pypi_build.yml
@@ -14,11 +14,8 @@ permissions:
 
 jobs:
   test_pypi_build:
-    name: >-
-      PyPI build test
-      (${{ matrix.os }}, ${{ matrix.install_target }}, ${{ matrix.requiredness }})
+    name: Test PyPI build (${{ matrix.os }}, ${{ matrix.install_target }})
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.allow_failure }}
     strategy:
       fail-fast: false
       matrix:
@@ -26,23 +23,15 @@ jobs:
           - os: ubuntu-latest
             install_target: base
             extra_selector: ""
-            allow_failure: false
-            requiredness: required
           - os: ubuntu-latest
             install_target: all
             extra_selector: "[all]"
-            allow_failure: false
-            requiredness: required
           - os: macos-latest
             install_target: base
             extra_selector: ""
-            allow_failure: true
-            requiredness: optional
           - os: macos-latest
             install_target: all
             extra_selector: "[all]"
-            allow_failure: true
-            requiredness: optional
     defaults:
       run:
         shell: bash
@@ -68,3 +57,14 @@ jobs:
           source .venv-pypi-smoke/bin/activate
           python -c "import queens"
           pytest -v -m "unit_tests" tests/unit_tests/
+
+  ensure_all_pypi_builds_pass:
+    name: Ensure all PyPI builds pass
+    needs: test_pypi_build
+    runs-on: ubuntu-latest
+    if: always() && github.ref != 'refs/heads/main'
+    steps:
+      - name: Check for successful PyPI builds
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
## Description and Context:<br> What and Why?
<!--
Provide a brief and concise description of your proposed change.
In particular: Why is this change required? What problem does it solve? Is this a breaking change?
-->
This PR adds two additional jobs to ensure that all PyPI builds and tests pass. This way, we only have to add these individual jobs to our branch protection rules instead of selecting each workflow job individually. Kudos to @rjoussen for pointing out that both [4C](https://github.com/4C-multiphysics/4C/blob/main/.github/workflows/buildtest.yml) and [FourCIPP](https://github.com/4C-multiphysics/fourcipp/blob/main/.github/workflows/run_testsuite.yaml) use this to simplify the branch protection rules and ensure that newly added jobs need to pass before a PR can be merged.

Note that I've also made the MacOS PyPI builds mandatory since we already claim in our documentation to support both Ubuntu and macOS on arm64.

While I was at it, I also unified the names of the workflow files and the workflows and jobs within them.

## Related Issues and Pull Requests
<!--
If applicable: how is this pull request related to other open issues or pull requests?
-->
* Closes
* Related to

## Interested Parties
<!--
If there's anyone you think should be looped in on this pull request,
feel free to @mention them here!
-->
@rjoussen 
@sbrandstaeter 

> Note: More information on the merge request procedure in QUEENS can be found in the [*Submit a pull request*](../CONTRIBUTING.md#5-submit-a-pull-request) section in the [CONTRIBUTING.md](../CONTRIBUTING.md) file.
